### PR TITLE
develop #45: zoom to search results, and limit the zoom level to 10

### DIFF
--- a/django_project/feti/models/campus.py
+++ b/django_project/feti/models/campus.py
@@ -29,19 +29,20 @@ class Campus(models.Model):
 
     @property
     def popup_content(self):
-        courses_string = '</li><li>'.join([c.course_description for c in
-                                           self.courses.all()])
+        courses_string = '</li><li>'.join([c.course_description for c
+                                           in self.courses.all()])
 
-        return ('<p>{} : {}</p>'
-                '<p>{}</p>'
-                '<p>Courses : '
-                '<br/>'
-                '<ul><li>{}</li></ul>'
-                '</p>').format(
+        result = (u'<p>{} : {}</p>'
+                  u'<p>{}</p>'
+                  u'<p>Courses : '
+                  u'<br/>'
+                  u'<ul><li>{}</li></ul>'
+                  u'</p>').format(
             self.campus,
-            self.provider.primary_institution,
+            self.provider,
             self.address,
             courses_string)
+        return result
 
     @property
     def geom(self):

--- a/django_project/feti/static/feti/js/feti.js
+++ b/django_project/feti/static/feti/js/feti.js
@@ -7,6 +7,9 @@ var campus_lookup = [];
 var campus_features = [];
 var campus_layer;
 var highlighted_feature;
+var fit_bounds_options = {
+    maxZoom: 10
+};
 
 jQuery.download = function (url, data, method) {
     /* Taken from http://www.filamentgroup.com/lab/jquery-plugin-for-requesting-ajax-like-file-downloads.html*/
@@ -120,7 +123,7 @@ function zoomToFeature(e) {
     'use strict';
     var layer;
     layer = e.target;
-    map.fitBounds(layer.getBounds());
+    map.fitBounds(layer.getBounds(), fit_bounds_options);
 }
 
 /*jslint unparam: true*/

--- a/django_project/feti/templates/feti/feti.html
+++ b/django_project/feti/templates/feti/feti.html
@@ -8,6 +8,7 @@
             {% for campus in course_dict %}
                 add_campus({{ campus|geojsonfeature:"popup_content"|safe }}, {{ campus.id }});
             {% endfor %}
+            map.fitBounds(campus_layer.getBounds(), fit_bounds_options);
         });
 
     </script>


### PR DESCRIPTION
- Zoom to search results after clicking search
- Limit the zoom level (useful when there are only 1 results) to 10
- Also add some bugfix for unicode popup content