### PR TITLE
Generate url

### DIFF
--- a/django_project/feti/admin.py
+++ b/django_project/feti/admin.py
@@ -163,6 +163,11 @@ class CourseAdmin(admin.ModelAdmin):
     related_providers.short_description = 'Related providers'
 
 
+class URLAdmin(admin.ModelAdmin):
+    """Admin Class for URL Model."""
+    list_display = ('url', 'random_string', 'date')
+    list_filter = ['url', 'random_string', 'date']
+    search_fields = ['url', 'random_string', 'date']
 
 
 admin.site.site_header = 'Feti Administration'
@@ -173,4 +178,4 @@ admin.site.register(Provider, ProviderAdmin)
 admin.site.register(Course, CourseAdmin)
 admin.site.register(LearningPathway, admin.ModelAdmin)
 admin.site.register(Step, admin.ModelAdmin)
-admin.site.register(URL)
+admin.site.register(URL, URLAdmin)

--- a/django_project/feti/admin.py
+++ b/django_project/feti/admin.py
@@ -15,6 +15,7 @@ from feti.models.course import Course
 from feti.models.provider import Provider
 from feti.models.occupation import Occupation
 from feti.models.learning_pathway import LearningPathway, Step
+from feti.models.url import URL
 
 
 class AddressAdmin(admin.ModelAdmin):
@@ -172,3 +173,4 @@ admin.site.register(Provider, ProviderAdmin)
 admin.site.register(Course, CourseAdmin)
 admin.site.register(LearningPathway, admin.ModelAdmin)
 admin.site.register(Step, admin.ModelAdmin)
+admin.site.register(URL)

--- a/django_project/feti/migrations/0043_auto_20160919_0515.py
+++ b/django_project/feti/migrations/0043_auto_20160919_0515.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feti', '0042_merge'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='step',
+            name='course',
+            field=models.ForeignKey(to='feti.Course', null=True, blank=True),
+        ),
+    ]

--- a/django_project/feti/migrations/0044_url.py
+++ b/django_project/feti/migrations/0044_url.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feti', '0043_auto_20160919_0515'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='URL',
+            fields=[
+                ('id', models.AutoField(primary_key=True, serialize=False)),
+                ('random_words', models.CharField(verbose_name='Random Words', max_length=255)),
+                ('url', models.URLField(verbose_name='Url', max_length=1000)),
+                ('date', models.DateField(verbose_name='Date', default=datetime.date.today)),
+            ],
+            options={
+                'verbose_name': 'URLs',
+                'ordering': ['date'],
+            },
+        ),
+    ]

--- a/django_project/feti/migrations/0045_auto_20160920_1427.py
+++ b/django_project/feti/migrations/0045_auto_20160920_1427.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feti', '0044_url'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='url',
+            options={'ordering': ['date'], 'verbose_name': 'URL'},
+        ),
+        migrations.RenameField(
+            model_name='url',
+            old_name='random_words',
+            new_name='random_string',
+        ),
+    ]

--- a/django_project/feti/models/__init__.py
+++ b/django_project/feti/models/__init__.py
@@ -18,6 +18,7 @@ from feti.models.national_qualifications_framework import (  # noqa
 from feti.models.provider import Provider  # noqa
 from feti.models.learning_pathway import LearningPathway  # noqa
 from feti.models.occupation import Occupation  # noqa
+from feti.models.url import URL  # noqa
 
 __author__ = 'Christian Christelis <christian@kartoza.com>'
 __date__ = '04/2015'

--- a/django_project/feti/models/url.py
+++ b/django_project/feti/models/url.py
@@ -11,7 +11,7 @@ class URL(models.Model):
 
     id = models.AutoField(primary_key=True)
 
-    random_words = models.CharField(
+    random_string = models.CharField(
         _("Random Words"),
         max_length=255,
         blank=False,

--- a/django_project/feti/models/url.py
+++ b/django_project/feti/models/url.py
@@ -1,0 +1,32 @@
+import datetime
+from django.contrib.gis.db import models
+from django.utils.translation import ugettext, ugettext_lazy as _
+
+__author__ = 'Dimas Ciputra <dimas@kartoza.com>'
+__date__ = '20/09/16'
+
+
+class URL(models.Model):
+    """Models to URL"""
+
+    id = models.AutoField(primary_key=True)
+
+    random_words = models.CharField(
+        _("Random Words"),
+        max_length=255,
+        blank=False,
+        null=False)
+    url = models.URLField(
+        _("Url"),
+        max_length=1000,
+        blank=False,
+        null=False)
+    date = models.DateField(_("Date"), default=datetime.date.today)
+
+    def __unicode__(self):
+        return self.random_words
+
+    class Meta:
+        app_label = 'feti'
+        ordering = ['date']
+        verbose_name = "URL"

--- a/django_project/feti/static/feti/js/scripts/routers/router.js
+++ b/django_project/feti/static/feti/js/scripts/routers/router.js
@@ -12,8 +12,7 @@ define([
             "map": "show_map",
             "map/:mode": "show_map",
             "map/:mode/:query": "show_map",
-            "map/:mode/:query/:filter": "show_map",
-            "url/:random_string": "get_url"
+            "map/:mode/:query/:filter": "show_map"
         },
         initialize: function () {
             this.loginView = new LoginView();
@@ -73,22 +72,6 @@ define([
             } else {
                 this.navigate('', true);
             }
-        },
-        get_url: function(random_string) {
-            $.ajax({
-                url:'api/get-url/'+random_string,
-                type:'GET',
-                success: function(response) {
-                    if(response=='') {
-                        this.navigate('', true);
-                    } else {
-                        this.navigate(response);
-                    }
-                },
-                error: function(response) {
-                    this.navigate('', true);
-                }
-            });
         }
     });
 

--- a/django_project/feti/static/feti/js/scripts/routers/router.js
+++ b/django_project/feti/static/feti/js/scripts/routers/router.js
@@ -13,6 +13,7 @@ define([
             "map/:mode": "show_map",
             "map/:mode/:query": "show_map",
             "map/:mode/:query/:filter": "show_map",
+            "url/:random_string": "get_url"
         },
         initialize: function () {
             this.loginView = new LoginView();
@@ -72,6 +73,22 @@ define([
             } else {
                 this.navigate('', true);
             }
+        },
+        get_url: function(random_string) {
+            $.ajax({
+                url:'api/get-url/'+random_string,
+                type:'GET',
+                success: function(response) {
+                    if(response=='') {
+                        this.navigate('', true);
+                    } else {
+                        this.navigate(response);
+                    }
+                },
+                error: function(response) {
+                    this.navigate('', true);
+                }
+            });
         }
     });
 

--- a/django_project/feti/static/feti/js/scripts/views/sharebar.js
+++ b/django_project/feti/static/feti/js/scripts/views/sharebar.js
@@ -91,7 +91,7 @@ define([
                 }),
                 success: function(response) {
                     var twitter_intent = 'https://twitter.com/intent/tweet?text=Check this out!%0A'+
-                        host+'/%23url/'+response;
+                        host+'/url/'+response;
                     // open twitter box
                     window.open(twitter_intent, '_blank', 'location=yes,height=570,width=520,scrollbars=yes,status=yes');
                 },

--- a/django_project/feti/static/feti/js/scripts/views/sharebar.js
+++ b/django_project/feti/static/feti/js/scripts/views/sharebar.js
@@ -77,13 +77,29 @@ define([
             });
         },
         shareToTwitter: function () {
+
             // get url
-            var url = Backbone.history.location.href.replace("#", "%23");
+            var full_url = Backbone.history.location.href;
+            var host = Backbone.history.location.host;
 
-            var twitter_intent = 'https://twitter.com/intent/tweet?text=Check this out!%0A'+url;
-
-            // open twitter box
-            window.open(twitter_intent, '_blank', 'location=yes,height=570,width=520,scrollbars=yes,status=yes');
+            // generate random string
+            $.ajax({
+                url:'api/generate-random-string/',
+                type:'POST',
+                data: JSON.stringify({
+                    'url': full_url
+                }),
+                success: function(response) {
+                    var twitter_intent = 'https://twitter.com/intent/tweet?text=Check this out!%0A'+
+                        host+'/%23url/'+response;
+                    // open twitter box
+                    window.open(twitter_intent, '_blank', 'location=yes,height=570,width=520,scrollbars=yes,status=yes');
+                },
+                error: function(response) {
+                },
+                complete: function() {
+                }
+            });
         }
     });
 

--- a/django_project/feti/urls.py
+++ b/django_project/feti/urls.py
@@ -10,7 +10,7 @@ from feti.views.campus import UpdateCampusView
 from feti.views.provider import UpdateProviderView
 from feti.views.landing_page import LandingPage
 from feti.views.api import ApiCampus, ApiCourse, ApiAutocomplete
-from feti.views.share import PDFDownload, EmailShare
+from feti.views.share import PDFDownload, EmailShare, ApiRandomString, ApiGetURL
 from feti.views.travel_time import TravelTime
 
 sqs = SearchQuerySet()
@@ -37,6 +37,16 @@ api_urls = patterns(
         r'^api/travel-time-seconds/(?P<origin>[\w\d]+)/(?P<destination>[\w\d]+)',
         TravelTime.as_view(response_type='data'),
         name='api-travel-time-seconds'),
+    url(
+        r'^api/generate-random-string/',
+        ApiRandomString.as_view(),
+        name="api-get-random-string"
+    ),
+    url(
+        r'^url/(?P<random>[\w\d]+)',
+        ApiGetURL.as_view(),
+        name="api-get-url"
+    )
 )
 
 urlpatterns = patterns(

--- a/django_project/feti/views/share.py
+++ b/django_project/feti/views/share.py
@@ -1,4 +1,5 @@
 import urllib.request
+from urllib.parse import unquote
 import weasyprint
 import os
 import json
@@ -188,7 +189,7 @@ class ApiRandomString(UpdateView):
             raise Http404(
                 'Error json value'
             )
-        url = retrieved_data['url']
+        url = unquote(retrieved_data['url'])
 
         response = self.generate_random_string(url)
 

--- a/django_project/feti/views/share.py
+++ b/django_project/feti/views/share.py
@@ -3,15 +3,19 @@ import weasyprint
 import os
 import json
 import smtplib
+from rest_framework.views import APIView
 from django.views.generic import TemplateView, UpdateView
 from django.http import HttpResponse, Http404
 from django.template.loader import get_template
 from django.template import RequestContext, Context
+from django.utils.crypto import get_random_string
 from django.utils._os import safe_join
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.mail import EmailMessage
+from django.shortcuts import redirect
 from feti.models.campus import Campus
+from feti.models.url import URL
 
 
 class SharingMixin(object):
@@ -155,3 +159,45 @@ class EmailShare(UpdateView, SharingMixin):
             )
 
         return HttpResponse('success')
+
+
+class ApiRandomString(UpdateView):
+
+    def generate_random_string(self, url):
+        """ Generate random string from url and store it to db"""
+        random = get_random_string()
+        while URL.objects.filter(random_string=random).exists():
+            random = get_random_string()
+
+        if URL.objects.filter(url=url).exists():
+            return URL.objects.filter(url=url).first().random_string
+
+        u = URL(
+            url=url,
+            random_string=random
+        )
+        u.save()
+        return random
+
+    def post(self, request, *args, **kwargs):
+        data = request.body
+
+        try:
+            retrieved_data = json.loads(data.decode("utf-8"))
+        except ValueError:
+            raise Http404(
+                'Error json value'
+            )
+        url = retrieved_data['url']
+
+        response = self.generate_random_string(url)
+
+        return HttpResponse(response)
+
+
+class ApiGetURL(APIView):
+
+    def get(self, request, random):
+        if URL.objects.filter(random_string=random).exists():
+            return redirect(URL.objects.filter(random_string=random).first().url)
+        return redirect('/')


### PR DESCRIPTION
Currently url is too long to be shared, for example : 

```
http://0.0.0.0:63102/#map/course/test/shape=polygon&coordinates=[{"lat":-31.43803717312445,"lng":17.7099609375},{"lat":-31.784216884487385,"lng":17.435302734375},{"lat":-31.87755764334002,"lng":17.435302734375},{"lat":-32.07326555104238,"lng":17.391357421875},{"lat":-32.24068253457368,"lng":17.33642578125},{"lat":-32.42634016154639,"lng":17.303466796875},{"lat":-32.53755174676898,"lng":17.2265625},{"lat":-32.78727452695549,"lng":17.24853515625},{"lat":-32.94414888814146,"lng":17.29248046875},{"lat":-33.02708758002873,"lng":17.347412109375},{"lat":-33.04550781490999,"lng":17.75390625},{"lat":-33.05471648804274,"lng":17.841796875},{"lat":-32.741082231501245,"lng":18.446044921875},{"lat":-32.62087018318112,"lng":18.577880859375},{"lat":-32.31499127724555,"lng":18.687744140625},{"lat":-31.85889704445453,"lng":18.775634765625},{"lat":-31.559814532018414,"lng":18.555908203125}]
```

This PR will add functionality to generate random string from the url, and store it to db. So when user wanted to share to twitter, it will look like this 
![url](https://cloud.githubusercontent.com/assets/1979569/18672387/2deb1ade-7f72-11e6-9d17-94399561156c.png)

When user open the url with the random string, it will redirect to correct url.
