### PR TITLE
Update model, scraper, and occupation view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - DATABASE_URL='postgres://postgres:@localhost:5432/test_db'
     - SECRET_KEY='tT\xd7\xb06\xf7\x9b\xff\x0fZL\xca\xca\x11\xefM\xacr\xfb\xdf\xca\x9b'
     - DJANGO_SETTINGS_MODULE=core.settings.test_travis
+    - RABBITMQ_HOST = 'rabbitmq'
 
 python:
   - '3.4.5'

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -320,6 +320,20 @@ clean-scraping:
 	@docker-compose -p $(PROJECT_ID) run uwsgi python manage.py scraping_course True
 	@docker-compose -p $(PROJECT_ID) run uwsgi python manage.py scraping_occupation True
 
+workerlogs:
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Showing celery worker logs in production mode"
+	@echo "------------------------------------------------------------------"
+	@docker-compose -p $(PROJECT_ID) logs worker
+
+worker:
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Running worker production mode"
+	@echo "------------------------------------------------------------------"
+	@docker-compose -p $(PROJECT_ID) up -d worker
+
 # ----------------------------------------------------------------------------
 #    DEVELOPMENT C O M M A N D S
 # --no-deps will attach to prod deps if running

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -304,6 +304,13 @@ scraping:
 	@docker-compose -p $(PROJECT_ID) run uwsgi python manage.py scraping_course
 	@docker-compose -p $(PROJECT_ID) run uwsgi python manage.py scraping_occupation
 
+scrape-occupation:
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Running command to scrap occupation data from internet"
+	@echo "------------------------------------------------------------------"
+	@docker-compose -p $(PROJECT_ID) run uwsgi python manage.py scraping_occupation > occupation_scrape.log
+
 clean-scraping:
 	@echo
 	@echo "------------------------------------------------------------------"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -76,6 +76,42 @@ dbbackups:
     - PGHOST=db
     - PGDATABASE=gis
 
+rabbitmq:
+  image: library/rabbitmq
+  hostname: rabbitmq
+  environment:
+     - RABBIT_PASSWORD=rabbit_test_password
+     - USER=rabbit_user
+     - RABBITMQ_NODENAME=rabbit
+
+worker:
+  build: docker
+  hostname: worker
+  command: celery worker -A feti.celery -l info  --beat
+  environment:
+    - DATABASE_NAME=gis
+    - DATABASE_USERNAME=docker
+    - DATABASE_PASSWORD=docker
+    - DATABASE_HOST=db
+    - DATABASE_QGIS_HOST=db_gis
+    - RABBITMQ_HOST=rabbitmq
+    - DJANGO_SETTINGS_MODULE=core.settings.prod_docker
+    - VIRTUAL_HOST=staging.feti.kartoza.com
+    - VIRTUAL_PORT=8080
+    - C_FORCE_ROOT=true
+    - HAYSTACK_HOST=elasticsearch
+  volumes:
+    - ../django_project:/home/web/django_project
+    - ./static:/home/web/static
+    - ./media:/home/web/media
+    - ./reports:/home/web/reports
+    - ./logs:/var/log/
+  links:
+    - smtp:smtp
+    - db:db
+    - elasticsearch:elasticsearch
+    - rabbitmq:rabbitmq
+
 uwsgi:
   # Note you cannot scale if you use conteiner_name
   container_name: feti-uwsgi
@@ -87,6 +123,7 @@ uwsgi:
     - DATABASE_USERNAME=docker
     - DATABASE_PASSWORD=docker
     - DATABASE_HOST=db
+    - RABBITMQ_HOST=rabbitmq
     - DJANGO_SETTINGS_MODULE=core.settings.prod_docker
     - VIRTUAL_HOST=users.inasafe.org
     - VIRTUAL_PORT=8080
@@ -102,6 +139,8 @@ uwsgi:
     - smtp:smtp
     - db:db
     - elasticsearch:elasticsearch
+    - rabbitmq:rabbitmq
+    - worker:worker
 
 # This is normally the main entry point for a production server
 web:
@@ -140,6 +179,7 @@ devweb:
     - PYTHONPATH=/home/web/django_project
     - VIRTUAL_HOST=feti.kartoza.com
     - VIRTUAL_PORT=8080
+    - RABBITMQ_HOST=rabbitmq
     - HAYSTACK_HOST=elasticsearch
   volumes:
     - ../django_project:/home/web/django_project
@@ -151,6 +191,8 @@ devweb:
     - smtp:smtp
     - db:db
     - elasticsearch:elasticsearch
+    - rabbitmq:rabbitmq
+    - worker:worker
   ports:
     # for django test server
     - "63102:8080"

--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -10,7 +10,7 @@ raven
 django-user-map
 django-forms-bootstrap
 # Django rest framework support
-djangorestframework>=3.2
+djangorestframework==3.5.3
 markdown
 django-filter
 # Django haystack support

--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -27,3 +27,4 @@ requests<2.12
 beautifulsoup4
 django-allauth
 django-betterforms
+celery<3.2

--- a/django_project/core/settings/celery_setting.py
+++ b/django_project/core/settings/celery_setting.py
@@ -1,0 +1,7 @@
+from datetime import timedelta
+
+# CELERYBEAT_SCHEDULE = {
+#
+# }
+
+CELERY_TIMEZONE = 'UTC'

--- a/django_project/core/settings/contrib.py
+++ b/django_project/core/settings/contrib.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .base import *  # noqa
+import os
 
 # Extra installed apps
 INSTALLED_APPS += (
@@ -15,6 +16,7 @@ INSTALLED_APPS += (
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
+    'celery',
 )
 
 SITE_ID = 1
@@ -55,3 +57,9 @@ HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
 GRAPPELLI_ADMIN_TITLE = 'Feti Administration'
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
+
+BROKER_URL = 'amqp://guest:guest@%s:5672//' % os.environ['RABBITMQ_HOST']
+
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'

--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -108,3 +108,5 @@ PIPELINE_CSS = {
 
 # Cache folder
 CACHE_DIR = ABS_PATH('cache')
+
+from .celery_setting import *  # noqa

--- a/django_project/feti/celery.py
+++ b/django_project/feti/celery.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+from celery import Celery
+from django.conf import settings
+from django.core.management import call_command
+
+app = Celery('feti')
+
+CELERY_TIMEZONE = settings.TIME_ZONE
+
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))
+
+
+@app.task(name="update_search_index")
+def update_search_index():
+    call_command('update_index')

--- a/django_project/feti/indexes/campus.py
+++ b/django_project/feti/indexes/campus.py
@@ -17,12 +17,16 @@ class CampusIndex(indexes.SearchIndex, indexes.Indexable):
 
     provider_primary_institution = indexes.EdgeNgramField()
     courses = indexes.CharField()
+    courses_id = indexes.CharField()
 
     def prepare_provider_primary_institution(self, obj):
         return obj.provider.primary_institution
 
     def prepare_courses(self, obj):
         return [l.course_description for l in obj.courses.all()]
+
+    def prepare_courses_id(self, obj):
+        return [l.id for l in obj.courses.all()]
 
     class Meta:
         app_label = 'feti'

--- a/django_project/feti/management/commands/scraping_campus.py
+++ b/django_project/feti/management/commands/scraping_campus.py
@@ -55,22 +55,22 @@ def create_address(data, campus):
     return address
 
 
-def scrape_campus(div):
+def scrape_campus(campus_name, campus_url):
     provider = {}
     campus = {}
     address = {}
 
     # parsing information
-    name = div.a.string
+    name = campus_name
     print("found : %s ----------------------------------------" % name)
-    provider['primary_institution'] = name.split('-')[0]
+    provider['primary_institution'] = name.split(' - ')[0]
     try:
         campus['campus'] = name.split('-')[1]
     except IndexError:
         campus['campus'] = ""
 
     # address
-    html = get_soup(div.a.get('href'))
+    html = get_soup(campus_url)
     html_address = html.find("div", {"class": "InstitutionAddress"})
     if html_address:
         website = html_address.a.string if html_address.a and "@" not in html_address.a.string else ""
@@ -124,6 +124,7 @@ def scrape_campus(div):
     prov = create_provider(provider)
     camp = create_campus(campus, prov)
     addr = create_address(address, camp)
+    return camp
 
 
 def scrape_all_campuses(start_page=0, max_page=0):
@@ -156,7 +157,7 @@ def scrape_all_campuses(start_page=0, max_page=0):
                 if div:
                     is_empty = False
                     print(div)
-                    scrape_campus(div)
+                    scrape_campus(div.a.string, div.a.get('href'))
             if is_empty:
                 break
         page += 1

--- a/django_project/feti/management/commands/scraping_campus.py
+++ b/django_project/feti/management/commands/scraping_campus.py
@@ -116,15 +116,11 @@ def scrape_campus(campus_name, campus_url):
                 except IndexError:
                     print('no location')
 
-    print(("provider : %s" % provider).encode('utf-8'))
-    print(("campus : %s" % campus).encode('utf-8'))
-    print(("address : %s" % address).encode('utf-8'))
-
     # save to database
-    prov = create_provider(provider)
-    camp = create_campus(campus, prov)
-    addr = create_address(address, camp)
-    return camp
+    provider_obj = create_provider(provider)
+    campus_obj = create_campus(campus, provider_obj)
+    address_obj = create_address(address, campus_obj)
+    return campus_obj
 
 
 def scrape_all_campuses(start_page=0, max_page=0):

--- a/django_project/feti/management/commands/scraping_course.py
+++ b/django_project/feti/management/commands/scraping_course.py
@@ -43,7 +43,7 @@ def create_or_update_course(data):
         data['title'] = data['qualification_title']
 
     if "id" in data:
-        print(("insert to database : %s" % data).encode('utf-8'))
+        print("insert to database")
         # getting education_training_quality_assurance
         education_training_quality_assurance = None
         if 'primary or delegated qa functionary' in data:

--- a/django_project/feti/management/commands/scraping_course.py
+++ b/django_project/feti/management/commands/scraping_course.py
@@ -70,36 +70,27 @@ def create_course(data):
         return course
 
 
-def process_saqa_qualification_table(table):
-    saqa_details = list(filter(None, table.text.split('\n')))
-    row_title = {
-        'saqa_qual_id': 'SAQA QUAL ID',
-        'title': 'QUALIFICATION TITLE',
-        'primary_or_delegated': 'PRIMARY OR DELEGATED QUALITY ASSURANCE FUNCTIONARY',
-        'nqf_level': 'NQF LEVEL',
-        'field': 'FIELD'
-    }
+def parse_saqa_qualification_table(table):
     data = {}
+    key_array = []
+    value_array = []
 
-    if row_title['saqa_qual_id'] in saqa_details:
-        index = saqa_details.index(row_title['saqa_qual_id'])
-        data['id'] = saqa_details[index + 2]
+    rows = table.findAll('tr')
 
-    if row_title['title'] in saqa_details:
-        index = saqa_details.index(row_title['title'])
-        data['title'] = saqa_details[index + 2]
+    for idx, row in enumerate(rows):
+        cols = row.findAll('td')
+        for col in cols:
+            if idx % 2:
+                value_array.append(cleaning(col.get_text()))
+            else:
+                key_array.append(cleaning(col.get_text())
+                                 .replace(" ", "_")
+                                 .replace("-", "_")
+                                 .lower())
 
-    if row_title['primary_or_delegated'] in saqa_details:
-        index = saqa_details.index(row_title['primary_or_delegated'])
-        data['primary or delegated qa functionary'] = saqa_details[index + 2]
-
-    if row_title['nqf_level'] in saqa_details:
-        index = saqa_details.index(row_title['nqf_level'])
-        data['nqf level'] = saqa_details[index + 5]
-
-    if row_title['field'] in saqa_details:
-        index = saqa_details.index(row_title['field'])
-        data['field'] = saqa_details[index + 3]
+    if len(key_array) == len(value_array):
+        for i in range(len(key_array)):
+            data[key_array[i]] = value_array[i]
 
     return data
 
@@ -128,7 +119,7 @@ def get_course_detail_from_saqa(qualification_id):
 
     if saqa_detail:
         tables = saqa_detail.findAll('table')
-        processed_table = process_saqa_qualification_table(tables[5])
+        processed_table = parse_saqa_qualification_table(tables[5])
         print(processed_table)
 
 
@@ -183,7 +174,7 @@ def scraping_course_ncap(start_page=0, max_page=0):
                 tables = saqa.findAll('table')
                 if len(tables) == 0:
                     continue
-                processed_table = process_saqa_qualification_table(tables[5])
+                processed_table = parse_saqa_qualification_table(tables[5])
                 course = create_course(processed_table)
 
             # Update campus

--- a/django_project/feti/management/commands/scraping_course.py
+++ b/django_project/feti/management/commands/scraping_course.py
@@ -43,7 +43,6 @@ def create_or_update_course(data):
         data['title'] = data['qualification_title']
 
     if "id" in data:
-        print("insert to database")
         # getting education_training_quality_assurance
         education_training_quality_assurance = None
         if 'primary or delegated qa functionary' in data:
@@ -174,40 +173,45 @@ def create_or_update_course(data):
         course.national_qualifications_subframework = nqfs
         course.pre_2009_national_qualifications_framework = pnqf
         course.abet_band = aband
-        course.minimum_credits = int(data['minimum_credits']) if 'minimum_credits' in data else None
-        course.registration_status = data['registration_status'] if 'registration_status' in data else None
-        course.saqa_decision_number = data['saqa_decision_number'] \
-            if 'saqa_decision_number' in data else None
-        course.registration_start_date = data['registration_start_date'] \
-            if 'registration_start_date' in data else None
-        course.registration_end_date = data['registration_end_date'] \
-            if 'registration_end_date' in data else None
-        course.last_date_for_enrolment = data['last_date_for_enrolment'] \
-            if 'last_date_for_enrolment' in data else None
-        course.last_date_for_achievement = data['last_date_for_achievement'] \
-            if 'last_date_for_achievement' in data else None
-        course.purpose_and_rationale_of_the_qualification = data['purpose_and_rationale_of_the_qualification'] \
-            if 'purpose_and_rationale_of_the_qualification' in data else None
-        course.learning_assumed_to_be_in_place_and_recognition = \
-            data['learning_assumed_to_be_in_place_and_recognition_of_prior_learning'] \
-            if 'learning_assumed_to_be_in_place_and_recognition_of_prior_learning' in data else None
-        course.qualification_rules = data['qualification_rules'] if 'qualification_rules' in data else None
-        course.exit_level_outcomes = data['exit_level_outcomes'] if 'exit_level_outcomes' in data else None
-        course.associated_assessment_criteria = data['associated_assessment_criteria'] \
-            if 'associated_assessment_criteria' in data else None
-        course.international_comparability = data['international_comparability'] \
-            if 'international_comparability' in data else None
-        course.articulation_options = data['articulation_options'] \
-            if 'articulation_options' in data else None
-        course.moderation_options = data['moderation_options'].lstrip() \
-            if 'moderation_options' in data else None
-        course.criteria_for_the_registration_of_assessors = \
-            data['criteria_for_the_registration_of_assessors'] \
-            if 'criteria_for_the_registration_of_assessors' in data else None
-        course.reregistration_history = data['reregistration_history'] \
-            if 'reregistration_history' in data else None
-        course.notes = data['notes'] if 'notes' in data else None
 
+        if 'minimum_credits' in data:
+            course.minimum_credits = int(data['minimum_credits'])
+        if 'registration_status' in data:
+            course.registration_status = data['registration_status']
+        if 'saqa_decision_number' in data:
+            course.saqa_decision_number = data['saqa_decision_number']
+        if 'registration_start_date' in data:
+            course.registration_start_date = data['registration_start_date']
+        if 'registration_end_date' in data:
+            course.registration_end_date = data['registration_end_date']
+        if 'last_date_for_enrolment' in data:
+            course.last_date_for_enrolment = data['last_date_for_enrolment']
+        if 'last_date_for_achievement' in data:
+            course.last_date_for_achievement = data['last_date_for_achievement']
+        if 'purpose_and_rationale_of_the_qualification' in data:
+            course.purpose_and_rationale_of_the_qualification = data['purpose_and_rationale_of_the_qualification']
+        if 'learning_assumed_to_be_in_place_and_recognition_of_prior_learning' in data:
+            course.learning_assumed_to_be_in_place_and_recognition = \
+                data['learning_assumed_to_be_in_place_and_recognition_of_prior_learning']
+        if 'qualification_rules' in data:
+            course.qualification_rules = data['qualification_rules']
+        if 'exit_level_outcomes' in data:
+            course.exit_level_outcomes = data['exit_level_outcomes']
+        if 'associated_assessment_criteria' in data:
+            course.associated_assessment_criteria = data['associated_assessment_criteria']
+        if 'international_comparability' in data:
+            course.international_comparability = data['international_comparability']
+        if 'articulation_options' in data:
+            course.articulation_options = data['articulation_options']
+        if 'moderation_options' in data:
+            course.moderation_options = data['moderation_options'].lstrip()
+        if 'criteria_for_the_registration_of_assessors' in data:
+            course.criteria_for_the_registration_of_assessors = \
+                data['criteria_for_the_registration_of_assessors']
+        if 'reregistration_history' in data:
+            course.reregistration_history = data['reregistration_history']
+        if 'notes' in data:
+            course.notes = data['notes']
         if 'recognise_previous_learning?' in data:
             course.recognise_previous_learning = True \
                 if cleaning(data['recognise_previous_learning?']) == 'Y' \

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -9,6 +9,7 @@ from feti.models.campus import Campus
 from feti.models.learning_pathway import LearningPathway, Step, StepDetail
 from feti.utils import beautify, get_soup, cleaning
 from feti.management.commands.scraping_course import get_course_detail_from_saqa
+from feti.management.commands.scraping_course import scrape_campus
 
 
 __author__ = 'Irwan Fathurrahman <irwan@kartoza.com>'
@@ -56,8 +57,9 @@ def process_course_and_provider(html, step_detail):
                     )[0]
             except (Campus.DoesNotExist, IndexError):
                 # Create provider with provider url
-                print('Campus not exists')
-                pass
+                campus = scrape_campus(
+                    provider_detail,
+                    'http://ncap.careerhelp.org.za/' + provider_url)
 
             if len(content_text_list) > 2:
                 for course_detail in content_text_list[2:]:
@@ -320,6 +322,10 @@ class Command(BaseCommand):
         page = 1
 
         print("GETTING OCCUPATIONS IN http://ncap.careerhelp.org.za/")
+
+        # For testing, get occupations from engineer page
+        # html = get_soup('http://ncap.careerhelp.org.za/occupations/search/engineer/page/1/')
+        # status = scraping_occupations(html=html)
 
         for char in character:
             while True:

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -69,6 +69,7 @@ def process_course_and_provider(html, step_detail):
                         ].split(':')[1].strip()
                     except IndexError as e:
                         print(e)
+                        continue
 
                     # Get course object
                     try:

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -1,13 +1,61 @@
 from django.core.management.base import BaseCommand
 
+import os
+from difflib import SequenceMatcher
+from django.conf import settings
 from feti.models.occupation import Occupation
+from feti.models.course import Course
+from feti.models.campus import Campus
 from feti.models.learning_pathway import LearningPathway, Step, StepDetail
 from feti.utils import beautify, get_soup, cleaning
+
 
 __author__ = 'Irwan Fathurrahman <irwan@kartoza.com>'
 __date__ = '15/09/16'
 __license__ = "GPL"
 __copyright__ = 'kartoza.com'
+
+
+def get_providers(html):
+    step_courses = []
+    beautified = beautify(html)
+    body = beautified.find("div", {"class": "BodyPanel642"})
+    if body:
+        contents = str(body)
+        contents = contents.split('<hr class="hrdivider"/>')
+        for content in contents:
+            cleaned = cleaning(content)
+            split = list(filter(None, cleaned.split('<br/>')))
+            if not beautify(split[0]).find('b'):
+                continue
+            # get provider
+
+            # get course
+            if 'SAQA Qualification ID' in split[2]:
+                course_content = split[2]
+
+                # get value inside parenthesis
+                value = course_content[course_content.index("(") + 1:course_content.rindex(")")]
+
+                # get id
+                course_id = value.split(',')[0].split(':')[1].strip()
+
+                # course title
+                course_title = course_content[0: course_content.index("(")].strip()
+
+                course = Course.objects.filter(
+                    national_learners_records_database=course_id,
+                    course_description__contains=course_title.lower()
+                )
+                if len(course) > 0:
+                    step_courses.append(course[len(course)-1])
+                else:
+                    # create course
+                    continue
+
+                print(course)
+            print(split)
+    print(step_courses)
 
 
 def create_step(data, learning_pathway):
@@ -19,7 +67,18 @@ def create_step(data, learning_pathway):
         step_detail = StepDetail()
     step_detail.title = data['title']
     step_detail.detail = data['detail']
-    step_detail.save()
+
+    if data['provider_link']:
+        # open link
+        provider_list_html = get_soup(data['provider_link'])
+        body = provider_list_html.find("div", {"class": "BodyPanel642"})
+
+        if body:
+            content = str(body)
+
+        # iterate on provider list
+
+    # step_detail.save()
 
     try:
         step = Step.objects.get(
@@ -68,146 +127,179 @@ def create_occupation(data):
     return occupation
 
 
+def scraping_occupations(html):
+    items = html.findAll("div", {"class": "LinkResult"})
+    if len(items) == 0:
+        print('this page is empty')
+        return False
+    else:
+        is_empty = False
+        # tracing each of item
+        for item in items:
+            if item.string and item.string == "No Records Found.":
+                is_empty = True
+                break
+            # get occupation information
+            if item.find("a", {"class": "linkNoMore"}):
+                pass
+            else:
+                occupation = dict()
+                occupation['occupation'] = cleaning(item.a.string.split("Occupation Code")[0][:-1])
+                occupation['green_occupation'] = False
+                occupation['scarce_skill'] = False
+                # checking green
+                if item.find("span", {"class": "greenTagListView"}):
+                    occupation['green_occupation'] = True
+                if item.find("span", {"class": "scarceTagListView"}):
+                    occupation['scarce_skill'] = True
+
+                # get detail
+                html = get_soup(item.a.get('href'))
+                body = html.find("div", {"class": "BodyPanel642"})
+                if body:
+                    content = str(body)
+                    content = content.split("<b>Description</b>")
+                    if len(content) > 1:
+                        content = content[1]
+                        # description
+                        occupation['description'] = cleaning(beautify(content.split("<b>")[0]).get_text())
+
+                        # tasks
+                        splits = content.split("<b>Tasks</b>")
+                        occupation['tasks'] = beautify(splits[1].split("<b>")[0]).get_text() \
+                            if len(splits) > 1 else ""
+                        occupation['tasks'] = cleaning(occupation['tasks'])
+
+                        # Occupation Regulation
+                        splits = content.split("<b>Occupation Regulation</b>")
+                        occupation['occupation_regulation'] = beautify(splits[1].split("<b>")[0]) \
+                            .get_text() \
+                            if len(splits) > 1 else ""
+                        occupation['occupation_regulation'] = cleaning(occupation['occupation_regulation'])
+
+                        # Learning Pathway Description
+                        splits = content.split("<b>Learning Pathway Description</b>")
+                        occupation['learning_pathway_description'] = beautify(
+                            splits[1].split("<a")[0]).get_text() \
+                            if len(splits) > 1 else ""
+                        occupation['learning_pathway_description'] = cleaning(
+                            occupation['learning_pathway_description'])
+
+                        # get learning pathway
+                        pathway_button = html.find("a", {"class": "btn_showLearningPathway"})
+                        occupation['learning_pathways'] = []
+                        if pathway_button:
+                            html = get_soup(pathway_button.get('href'))
+                            wrapper = html.find("div", {"id": "tabwrapper"})
+                            if wrapper:
+                                pathways = []
+                                pathways_html = wrapper.findAll("div")
+                                pathway_number = 1
+
+                                # check every pathways
+                                for pathway_html in pathways_html:
+                                    if pathway_html.get('id') and 'pathway' in pathway_html.get('id'):
+                                        steps_html = pathway_html.findAll("table")
+                                        steps = []
+                                        step_number = 1
+                                        # get steps
+                                        for step_html in steps_html:
+                                            step_content = step_html. \
+                                                find("div", {"class": "pathItemContent"})
+                                            title = step_content.b.string
+                                            detail = str(step_content).split("<br/>")
+                                            detail = detail[len(detail) - 1]
+
+                                            # assign value
+                                            step = {}
+                                            step['step_number'] = step_number
+
+                                            # cleaning value
+                                            step['title'] = cleaning(beautify(title).get_text())
+                                            step['detail'] = cleaning(beautify(detail).get_text())
+
+                                            # get providers that offer this qualification
+                                            if step_content.find('a'):
+                                                step['provider_link'] = step_content.find('a').get('href')
+
+                                            steps.append(step)
+                                            step_number += 1
+
+                                        pathway = {}
+                                        pathway['pathway_number'] = pathway_number
+                                        pathway['steps'] = steps
+                                        pathways.append(pathway)
+                                        pathway_number += 1
+
+                                occupation['learning_pathways'] = pathways
+
+                        print(("occupation : %s" % occupation).encode('utf-8'))
+                        # set to database
+                        create_occupation(occupation)
+        if is_empty:
+            return False
+    return True
+
+
 class Command(BaseCommand):
+    help = 'Scrapping the occupation information'
     args = '<args>'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--char',
+            dest='char',
+            help='Range of character to scrap from ncap list'
+        )
+        parser.add_argument(
+            '--limitpage',
+            dest='limitpage',
+            help='Page limit'
+        )
+
     def handle(self, *args, **options):
-        args = list(args)
-        if len(args) > 0:
-            if args[len(args) - 1].lower() == "true":
-                LearningPathway.objects.all().delete()
-                Occupation.objects.all().delete()
-                Step.objects.all().delete()
-                args.pop(len(args) - 1)
-            elif args[len(args) - 1].lower() == "false":
-                args.pop(len(args) - 1)
+
         # ----------------------------------------------------------
         # http://ncap.careerhelp.org.za/
         # ----------------------------------------------------------
         character = "abcdefghijklmnopqrstuvwxyz"
+
         # check if there is input for character range
-        if len(args) > 0:
-            if args[0].lower() != "true" and args[0].lower() != "false":
-                range = args[0].split("-")
-                low = character.index(range[0])
-                high = character.index(range[len(range) - 1])
-                character = character[low:high]
+        if options['char']:
+            char_range = options['char'].split("-")
+            low = character.index(char_range[0])
+            high = character.index(char_range[len(char_range) - 1])
+            character = character[low:high]
+
+        limit_page = 0
+
+        if options['limitpage'] and options['limitpage'].isdigit():
+            limit_page = options['limitpage']
         page = 1
+
         print("GETTING OCCUPATIONS IN http://ncap.careerhelp.org.za/")
         print("----------------------------------------------------------")
-        for char in character:
-            while True:
-                # get all of list
-                print("processing '%s' page %d" % (char, page))
-                html = get_soup('http://ncap.careerhelp.org.za/occupations/alphabetical/%s/page/%s/' %
-                                (char, page))
-                items = html.findAll("div", {"class": "SearchResultItem"})
-                if len(items) == 0:
-                    print('this page is empty')
-                    break
-                elif len(items) >= 1:
-                    is_empty = False
-                    # tracing each of item
-                    for item in items:
-                        if item.string and item.string == "No Records Found.":
-                            is_empty = True
-                            break
-                        # get occupation information
-                        if item.find("a", {"class": "linkNoMore"}):
-                            pass
-                        else:
-                            occupation = {}
-                            occupation['occupation'] = cleaning(item.a.string.split("Occupation Code")[0][:-1])
-                            occupation['green_occupation'] = False
-                            occupation['scarce_skill'] = False
-                            # checking green
-                            if item.find("span", {"class": "greenTagListView"}):
-                                occupation['green_occupation'] = True
-                            if item.find("span", {"class": "scarceTagListView"}):
-                                occupation['scarce_skill'] = True
 
-                            # get detail
-                            html = get_soup(item.a.get('href'))
-                            body = html.find("div", {"class": "BodyPanel642"})
-                            if body:
-                                content = str(body)
-                                content = content.split("<b>Description</b>")
-                                if len(content) > 1:
-                                    content = content[1]
-                                    # description
-                                    occupation['description'] = beautify(content.split("<b>")[0]).get_text()
-                                    occupation['description'] = cleaning(occupation['description'])
+        # For testing, get occupations from engineer page
+        html = get_soup('http://ncap.careerhelp.org.za/occupations/search/engineer/page/1/')
+        # status = scraping_occupations(html=html)
 
-                                    # tasks
-                                    splits = content.split("<b>Tasks</b>")
-                                    occupation['tasks'] = beautify(splits[1].split("<b>")[0]).get_text() \
-                                        if len(splits) > 1 else ""
-                                    occupation['tasks'] = cleaning(occupation['tasks'])
+        html_text = open(os.path.join(settings.STATIC_ROOT, 'feti/html/ncap1.html'), 'rb').read()
+        get_providers(html_text)
 
-                                    # Occupation Regulation
-                                    splits = content.split("<b>Occupation Regulation</b>")
-                                    occupation['occupation_regulation'] = beautify(splits[1].split("<b>")[0])\
-                                        .get_text() \
-                                        if len(splits) > 1 else ""
-                                    occupation['occupation_regulation'] = cleaning(occupation['occupation_regulation'])
-
-                                    # Learning Pathway Description
-                                    splits = content.split("<b>Learning Pathway Description</b>")
-                                    occupation['learning_pathway_description'] = beautify(
-                                        splits[1].split("<a")[0]).get_text() \
-                                        if len(splits) > 1 else ""
-                                    occupation['learning_pathway_description'] = cleaning(
-                                        occupation['learning_pathway_description'])
-
-                                    # get learning pathway
-                                    pathway_button = html.find("a", {"class": "btn_showLearningPathway"})
-                                    occupation['learning_pathways'] = []
-                                    if pathway_button:
-                                        html = get_soup(pathway_button.get('href'))
-                                        wrapper = html.find("div", {"id": "tabwrapper"})
-                                        if wrapper:
-                                            pathways = []
-                                            pathways_html = wrapper.findAll("div")
-                                            pathway_number = 1
-
-                                            # check every pathways
-                                            for pathway_html in pathways_html:
-                                                if pathway_html.get('id') and 'pathway' in pathway_html.get('id'):
-                                                    steps_html = pathway_html.findAll("table")
-                                                    steps = []
-                                                    step_number = 1
-                                                    # get steps
-                                                    for step_html in steps_html:
-                                                        step_content = step_html.\
-                                                            find("div", {"class": "pathItemContent"})
-                                                        title = step_content.b.string
-                                                        detail = str(step_content).split("<br/>")
-                                                        detail = detail[len(detail) - 1]
-
-                                                        # assign value
-                                                        step = {}
-                                                        step['step_number'] = step_number
-
-                                                        # cleaning value
-                                                        step['title'] = cleaning(beautify(title).get_text())
-                                                        step['detail'] = cleaning(beautify(detail).get_text())
-                                                        steps.append(step)
-                                                        step_number += 1
-
-                                                    pathway = {}
-                                                    pathway['pathway_number'] = pathway_number
-                                                    pathway['steps'] = steps
-                                                    pathways.append(pathway)
-                                                    pathway_number += 1
-
-                                            occupation['learning_pathways'] = pathways
-
-                                    print(("occupation : %s" % occupation).encode('utf-8'))
-                                    # set to database
-                                    create_occupation(occupation)
-                    if is_empty:
-                        break
-                page += 1
-                print("----------------------------------------------------------")
-            page = 1
-        print("----------------------------------------------------------")
+        # for char in character:
+        #     while True:
+        #         # get all of list
+        #         print("processing '%s' page %d" % (char, page))
+        #         html = get_soup('http://ncap.careerhelp.org.za/occupations/alphabetical/%s/page/%s/' %
+        #                         (char, page))
+        #         status = scraping_occupations(html)
+        #         if not status:
+        #             break
+        #         page += 1
+        #         if page > limit_page > 0:
+        #             break
+        #
+        #         print("----------------------------------------------------------")
+        #     page = 1
+        # print("----------------------------------------------------------")

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -1,8 +1,6 @@
 from django.core.management.base import BaseCommand
 
-import os
-from difflib import SequenceMatcher
-from django.conf import settings
+from django.db.utils import IntegrityError
 from feti.models.occupation import Occupation
 from feti.models.course import Course
 from feti.models.campus import Campus
@@ -112,10 +110,14 @@ def create_step(data, learning_pathway):
             learning_pathway=learning_pathway)
     except Step.DoesNotExist:
         step = Step()
-    step.step_number = data['step_number']
-    step.learning_pathway = learning_pathway
-    step.step_detail = step_detail
-    step.save()
+    try:
+        step.step_number = data['step_number']
+        step.learning_pathway = learning_pathway
+        step.step_detail = step_detail
+        step.save()
+    except IntegrityError as e:
+        print(e)
+        return None
 
     if 'provider_link' in data:
         # open link

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -141,6 +141,8 @@ def create_occupation(data):
     except Occupation.DoesNotExist:
         occupation = Occupation()
 
+    print('Create/Update occupation {}'.format(data['occupation']))
+
     occupation.occupation = data['occupation']
     occupation.green_occupation = data['green_occupation']
     occupation.scarce_skill = data['scarce_skill']
@@ -163,7 +165,7 @@ def create_occupation(data):
 
 
 def scraping_occupations(html):
-    items = html.findAll("div", {"class": "LinkResult"})
+    items = html.findAll("div", {"class": "SearchResultItem"})
     if len(items) == 0:
         print('this page is empty')
         return False

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -44,14 +44,26 @@ def get_providers(html):
                 course_title = course_content[0: course_content.index("(")].strip()
 
                 course = Course.objects.filter(
-                    national_learners_records_database=course_id,
-                    course_description__contains=course_title.lower()
+                    national_learners_records_database=course_id
                 )
-                if len(course) > 0:
-                    step_courses.append(course[len(course)-1])
-                else:
-                    # create course
-                    continue
+
+                # if there are more than 1 courses, something wrong
+                if len(course) > 1:
+                    # find the closest one
+                    current_ratio = 0
+                    correct_course = None
+
+                    for c in course:
+                        ratio = SequenceMatcher(None, course_title, c.course_description).ratio()
+
+                        if 0.5 < ratio > current_ratio:
+                            # delete course
+                            # if correct_course:
+                            #     correct_course.delete()
+                            correct_course = c
+
+                    if correct_course:
+                        step_courses.append(correct_course)
 
                 print(course)
             print(split)

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -144,8 +144,6 @@ def create_occupation(data):
     except Occupation.DoesNotExist:
         occupation = Occupation()
 
-    print('Create/Update occupation {}'.format(data['occupation']))
-
     occupation.occupation = data['occupation']
     occupation.green_occupation = data['green_occupation']
     occupation.scarce_skill = data['scarce_skill']
@@ -207,28 +205,31 @@ def scraping_occupations(html):
                     if len(content) > 1:
                         content = content[1]
                         # description
-                        occupation['description'] = cleaning(beautify(content.split("<b>")[0]).get_text())
+                        occupation['description'] = \
+                            cleaning(beautify(content.split("<b>")[0]).get_text())
 
                         # tasks
                         splits = content.split("<b>Tasks</b>")
-                        occupation['tasks'] = beautify(splits[1].split("<b>")[0]).get_text() \
-                            if len(splits) > 1 else ""
-                        occupation['tasks'] = cleaning(occupation['tasks'])
+                        if len(splits) > 1:
+                            occupation['tasks'] = cleaning(beautify(splits[1].split("<b>")[0]).get_text())
+                        else:
+                            occupation['tasks'] = ""
 
                         # Occupation Regulation
                         splits = content.split("<b>Occupation Regulation</b>")
-                        occupation['occupation_regulation'] = beautify(splits[1].split("<b>")[0]) \
-                            .get_text() \
-                            if len(splits) > 1 else ""
-                        occupation['occupation_regulation'] = cleaning(occupation['occupation_regulation'])
+                        if len(splits) > 1:
+                            occupation['occupation_regulation'] = cleaning(
+                                beautify(splits[1].split("<b>")[0]).get_text())
+                        else:
+                            occupation['occupation_regulation'] = ""
 
                         # Learning Pathway Description
                         splits = content.split("<b>Learning Pathway Description</b>")
-                        occupation['learning_pathway_description'] = beautify(
-                            splits[1].split("<a")[0]).get_text() \
-                            if len(splits) > 1 else ""
-                        occupation['learning_pathway_description'] = cleaning(
-                            occupation['learning_pathway_description'])
+                        if len(splits) > 1:
+                            occupation['learning_pathway_description'] = cleaning(beautify(
+                                splits[1].split("<a")[0]).get_text())
+                        else:
+                            occupation['learning_pathway_description'] = ""
 
                         # get learning pathway
                         pathway_button = html.find("a", {"class": "btn_showLearningPathway"})
@@ -274,9 +275,10 @@ def scraping_occupations(html):
                                             steps.append(step)
                                             step_number += 1
 
-                                        pathway = dict()
-                                        pathway['pathway_number'] = pathway_number
-                                        pathway['steps'] = steps
+                                        pathway = {
+                                            'pathway_number': pathway_number,
+                                            'steps': steps
+                                        }
                                         pathways.append(pathway)
                                         pathway_number += 1
 

--- a/django_project/feti/management/commands/scraping_occupation.py
+++ b/django_project/feti/management/commands/scraping_occupation.py
@@ -321,36 +321,19 @@ class Command(BaseCommand):
 
         print("GETTING OCCUPATIONS IN http://ncap.careerhelp.org.za/")
 
-        # For testing, get occupations from engineer page
-        html = get_soup('http://ncap.careerhelp.org.za/occupations/search/engineer/page/1/')
-        status = scraping_occupations(html=html)
+        for char in character:
+            while True:
+                # get all of list
+                print("processing '%s' page %d" % (char, page))
+                html = get_soup('http://ncap.careerhelp.org.za/occupations/alphabetical/%s/page/%s/' %
+                                (char, page))
+                status = scraping_occupations(html)
+                if not status:
+                    break
+                page += 1
+                if page > limit_page > 0:
+                    break
 
-        print(status)
-
-        # occupation_title = 'COMPUTER ENGINEERING MECHANIC'
-        #
-        # occupation = Occupation.objects.get(occupation__iexact=occupation_title)
-        # learning_pathway = LearningPathway.objects.filter(occupation=occupation)
-        # step = Step.objects.get(learning_pathway=learning_pathway[5], step_number=2)
-        # html_text = get_soup('http://ncap.careerhelp.org.za/learningprovidersforqualification/'
-        #                      'generalqualification/6ffde8f3-cd3d-4f63-a10c-4ddf460cb590/'
-        #                      'occupation/3c5fb117-0f81-423b-8b1d-58c76fd71c71')
-        #
-        # process_course_and_provider(html_text, step.step_detail)
-
-        # for char in character:
-        #     while True:
-        #         # get all of list
-        #         print("processing '%s' page %d" % (char, page))
-        #         html = get_soup('http://ncap.careerhelp.org.za/occupations/alphabetical/%s/page/%s/' %
-        #                         (char, page))
-        #         status = scraping_occupations(html)
-        #         if not status:
-        #             break
-        #         page += 1
-        #         if page > limit_page > 0:
-        #             break
-        #
-        #         print("----------------------------------------------------------")
-        #     page = 1
-        # print("----------------------------------------------------------")
+                print("----------------------------------------------------------")
+            page = 1
+        print("----------------------------------------------------------")

--- a/django_project/feti/management/commands/update_courses.py
+++ b/django_project/feti/management/commands/update_courses.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+"""A command to update courses data, the new data will be fetch from saqa site"""
+from django.core.management.base import BaseCommand
+from django.db.utils import IntegrityError as dbIntegrityError
+from psycopg2 import IntegrityError
+from feti.models.course import Course
+from feti.models.campus import Campus
+from feti.management.commands.scraping_course import get_course_detail_from_saqa
+
+
+class Command(BaseCommand):
+    """
+    Update all courses to saqa equivalents and remove duplicates course
+    """
+    args = ''
+    # noinspection PyShadowBuiltins
+    help = 'Update all courses from local database'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--id',
+            dest='id',
+            help='Qualification id'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Implementation for command
+        :param args: Not used
+        :param options: qualification id
+        """
+        if options['id']:
+            courses = Course.objects.filter(national_learners_records_database=options['id'])
+        else:
+            courses = Course.objects.all()
+
+        for course in courses:
+            if course.national_learners_records_database:
+                print('-----------------------------------------------')
+                print('Processing {} - {}'.format(
+                    course.national_learners_records_database,
+                    course.course_description))
+                # check duplicates
+                duplicates = courses.filter(
+                    national_learners_records_database=course.national_learners_records_database
+                ).exclude(id=course.id)
+                if len(duplicates) > 0:
+                    print("Removing duplicates")
+                    campuses = Campus.objects.filter(courses__in=duplicates)
+                    for campus in campuses:
+                        try:
+                            campus.courses.add(course)
+                        except (IntegrityError, dbIntegrityError) as e:
+                            print(e)
+                            break
+                    duplicates.delete()
+
+                print('Updating from saqa sites by qualification id')
+                get_course_detail_from_saqa(course.national_learners_records_database)

--- a/django_project/feti/management/commands/update_courses.py
+++ b/django_project/feti/management/commands/update_courses.py
@@ -56,4 +56,4 @@ class Command(BaseCommand):
                     duplicates.delete()
 
                 print('Updating from saqa sites by qualification id')
-                get_course_detail_from_saqa(course.national_learners_records_database)
+                get_course_detail_from_saqa(course.national_learners_records_database, False)

--- a/django_project/feti/migrations/0054_auto_20161103_0524.py
+++ b/django_project/feti/migrations/0054_auto_20161103_0524.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feti', '0053_campuscoursesfavorite_user'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='stepdetail',
+            name='course',
+        ),
+        migrations.AddField(
+            model_name='stepdetail',
+            name='course',
+            field=models.ManyToManyField(null=True, blank=True, to='feti.Course'),
+        ),
+    ]

--- a/django_project/feti/migrations/0055_auto_20161104_0557.py
+++ b/django_project/feti/migrations/0055_auto_20161104_0557.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feti', '0054_auto_20161103_0524'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AbetBand',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('band', models.CharField(max_length=150)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='NationalQualificationFrameworkSubFramework',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('code', models.CharField(max_length=50)),
+                ('title', models.CharField(blank=True, null=True, max_length=150)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Pre2009NationalQualificationsFramework',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('level', models.CharField(max_length=150)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='QualClass',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=150)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='QualificationType',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('type', models.CharField(max_length=150)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='SubFieldOfStudy',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('learning_subfield', models.CharField(max_length=150)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='articulation_options',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='associated_assessment_criteria',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='criteria_for_the_registration_of_assessors',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='exit_level_outcomes',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='international_comparability',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='last_date_for_achievement',
+            field=models.DateField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='last_date_for_enrolment',
+            field=models.DateField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='learning_assumed_to_be_in_place_and_recognition',
+            field=models.TextField(blank=True, verbose_name='Learning Assumed To Be In Place And Recognition Of Prior Learning', null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='minimum_credits',
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='moderation_options',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='notes',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='purpose_and_rationale_of_the_qualification',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='qualification_rules',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='recognise_previous_learning',
+            field=models.NullBooleanField(default=None),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='registration_end_date',
+            field=models.DateField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='registration_start_date',
+            field=models.DateField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='registration_status',
+            field=models.NullBooleanField(default=None),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='reregistration_history',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='saqa_decision_number',
+            field=models.CharField(blank=True, null=True, max_length=150),
+        ),
+        migrations.AlterField(
+            model_name='stepdetail',
+            name='course',
+            field=models.ManyToManyField(blank=True, to='feti.Course'),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='abet_band',
+            field=models.ForeignKey(blank=True, null=True, to='feti.AbetBand'),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='national_qualifications_subframework',
+            field=models.ForeignKey(blank=True, null=True, to='feti.NationalQualificationFrameworkSubFramework'),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='pre_2009_national_qualifications_framework',
+            field=models.ForeignKey(blank=True, null=True, to='feti.Pre2009NationalQualificationsFramework'),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='qual_class',
+            field=models.ForeignKey(blank=True, null=True, to='feti.QualClass'),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='qualification_type',
+            field=models.ForeignKey(blank=True, null=True, to='feti.QualificationType'),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='subfield_of_study',
+            field=models.ForeignKey(blank=True, null=True, to='feti.SubFieldOfStudy'),
+        ),
+    ]

--- a/django_project/feti/migrations/0056_auto_20161104_1255.py
+++ b/django_project/feti/migrations/0056_auto_20161104_1255.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feti', '0055_auto_20161104_0557'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='course',
+            name='registration_status',
+            field=models.CharField(max_length=100, null=True, blank=True),
+        ),
+    ]

--- a/django_project/feti/models/abet_band.py
+++ b/django_project/feti/models/abet_band.py
@@ -1,0 +1,19 @@
+from django.contrib.gis.db import models
+
+
+class AbetBand(models.Model):
+    band = models.CharField(
+        max_length=150,
+        blank=False,
+        null=False)
+
+    objects = models.GeoManager()
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return self.band
+
+    class Meta:
+        app_label = 'feti'

--- a/django_project/feti/models/campus.py
+++ b/django_project/feti/models/campus.py
@@ -122,7 +122,7 @@ class Campus(models.Model):
     def save(self, *args, **kwargs):
         # set up long description
         from_inline = False
-        super(Campus, self).save(*args, **kwargs)
+        # super(Campus, self).save(*args, **kwargs)
 
         try:
             self.address_fk
@@ -176,6 +176,8 @@ class Campus(models.Model):
         }
         self._campus_popup = template.render(Context(variable))
 
+        super(Campus, self).save(*args, **kwargs)
+
         # save the key in address
         if self.address:
             self.address_fk = self.address
@@ -203,8 +205,6 @@ class Campus(models.Model):
         for entry in campus_course_entries:
             if entry.course.id not in course_ids:
                 entry.delete()
-
-        super(Campus, self).save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
         # delete campus course entries

--- a/django_project/feti/models/campus.py
+++ b/django_project/feti/models/campus.py
@@ -3,12 +3,15 @@
 
 from django.contrib.gis.db import models
 from django.core import management
-from django.db.models.signals import post_save
 from django.template import Context, loader
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 
 from feti.models.provider import Provider
 from feti.models.course import Course
 from feti.models.address import Address
+
+from feti.celery import update_search_index
 
 __author__ = 'Christian Christelis <christian@kartoza.com>'
 __date__ = '04/2015'
@@ -215,3 +218,8 @@ class Campus(models.Model):
 
 def generate_campus_index(sender, instance, **kwargs):
     management.call_command('generate_campus_index')
+
+
+@receiver(post_save, sender=Campus)
+def update_index(sender, instance, **kwargs):
+    update_search_index.delay()

--- a/django_project/feti/models/course.py
+++ b/django_project/feti/models/course.py
@@ -100,10 +100,10 @@ class Course(models.Model):
         null=True
     )
 
-    registration_status = models.NullBooleanField(
+    registration_status = models.CharField(
+        max_length=100,
         blank=True,
-        null=True,
-        default=None
+        null=True
     )
 
     saqa_decision_number = models.CharField(

--- a/django_project/feti/models/course.py
+++ b/django_project/feti/models/course.py
@@ -21,6 +21,8 @@ from feti.models.qual_class import QualClass
 from feti.models.national_qualification_framework_subframework import \
     NationalQualificationFrameworkSubFramework
 from feti.models.abet_band import AbetBand
+from feti.models.pre_2009_national_qualifications_framework import \
+    Pre2009NationalQualificationsFramework
 
 __author__ = 'Christian Christelis <christian@kartoza.com>'
 __date__ = '04/2015'
@@ -52,13 +54,13 @@ class Course(models.Model):
         NationalQualificationsFramework, blank=True, null=True)
 
     national_qualifications_subframework = models.ForeignKey(
-        NationalQualificationFrameworkSubFramework,
-        blank=True,
-        null=True
+            NationalQualificationFrameworkSubFramework,
+            blank=True,
+            null=True
     )
 
     pre_2009_national_qualifications_framework = models.ForeignKey(
-            NationalQualificationsFramework,
+            Pre2009NationalQualificationsFramework,
             blank=True,
             null=True
     )
@@ -135,7 +137,8 @@ class Course(models.Model):
         null=True
     )
 
-    learning_assumed_to_be_in_place_and_recognition_of_prior_learning = models.TextField(
+    learning_assumed_to_be_in_place_and_recognition = models.TextField(
+        verbose_name="Learning Assumed To Be In Place And Recognition Of Prior Learning",
         blank=True,
         null=True
     )

--- a/django_project/feti/models/course.py
+++ b/django_project/feti/models/course.py
@@ -15,6 +15,12 @@ from feti.models.national_graduate_school_in_education import (
 from feti.models.national_certificate_vocational import (
     NationalCertificateVocational)
 from feti.models.field_of_study import FieldOfStudy
+from feti.models.subfield_of_study import SubFieldOfStudy
+from feti.models.qualification_type import QualificationType
+from feti.models.qual_class import QualClass
+from feti.models.national_qualification_framework_subframework import \
+    NationalQualificationFrameworkSubFramework
+from feti.models.abet_band import AbetBand
 
 __author__ = 'Christian Christelis <christian@kartoza.com>'
 __date__ = '04/2015'
@@ -41,13 +47,149 @@ class Course(models.Model):
         null=True)
     education_training_quality_assurance = models.ForeignKey(
         EducationTrainingQualityAssurance, blank=True, null=True)
+
     national_qualifications_framework = models.ForeignKey(
         NationalQualificationsFramework, blank=True, null=True)
+
+    national_qualifications_subframework = models.ForeignKey(
+        NationalQualificationFrameworkSubFramework,
+        blank=True,
+        null=True
+    )
+
+    pre_2009_national_qualifications_framework = models.ForeignKey(
+            NationalQualificationsFramework,
+            blank=True,
+            null=True
+    )
+
     national_graduate_school_in_education = models.ForeignKey(
         NationalGraduateSchoolInEducation, blank=True, null=True)
     national_certificate_vocational = models.ForeignKey(
         NationalCertificateVocational, blank=True, null=True)
     field_of_study = models.ForeignKey(FieldOfStudy, blank=True, null=True)
+
+    subfield_of_study = models.ForeignKey(
+            SubFieldOfStudy,
+            blank=True,
+            null=True
+    )
+
+    abet_band = models.ForeignKey(
+        AbetBand,
+        blank=True,
+        null=True
+    )
+
+    minimum_credits = models.PositiveIntegerField(
+        blank=True,
+        null=True
+    )
+
+    qualification_type = models.ForeignKey(
+        QualificationType,
+        blank=True,
+        null=True
+    )
+
+    qual_class = models.ForeignKey(
+        QualClass,
+        blank=True,
+        null=True
+    )
+
+    registration_status = models.NullBooleanField(
+        blank=True,
+        null=True,
+        default=None
+    )
+
+    saqa_decision_number = models.CharField(
+        max_length=150,
+        blank=True,
+        null=True
+    )
+
+    registration_start_date = models.DateField(
+        blank=True,
+        null=True
+    )
+
+    registration_end_date = models.DateField(
+        blank=True,
+        null=True
+    )
+
+    last_date_for_enrolment = models.DateField(
+        blank=True,
+        null=True
+    )
+
+    last_date_for_achievement = models.DateField(
+        blank=True,
+        null=True
+    )
+
+    purpose_and_rationale_of_the_qualification = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    learning_assumed_to_be_in_place_and_recognition_of_prior_learning = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    recognise_previous_learning = models.NullBooleanField(
+        blank=True,
+        null=True,
+        default=None
+    )
+
+    qualification_rules = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    exit_level_outcomes = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    associated_assessment_criteria = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    international_comparability = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    articulation_options = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    moderation_options = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    criteria_for_the_registration_of_assessors = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    reregistration_history = models.TextField(
+        blank=True,
+        null=True
+    )
+
+    notes = models.TextField(
+        blank=True,
+        null=True
+    )
 
     # Decreasing the number of links needed to other models for descriptions.
     _long_description = models.CharField(
@@ -124,6 +266,7 @@ class Course(models.Model):
     class Meta:
         app_label = 'feti'
         managed = True
+
 
 def generate_course_index(sender, instance, **kwargs):
     management.call_command('generate_course_index')

--- a/django_project/feti/models/learning_pathway.py
+++ b/django_project/feti/models/learning_pathway.py
@@ -12,7 +12,7 @@ class StepDetail(models.Model):
     id = models.AutoField(primary_key=True)
     title = models.CharField(max_length=255, null=True, blank=True)
     detail = models.CharField(max_length=1024, null=True, blank=True)
-    course = models.ForeignKey(Course, null=True, blank=True)
+    course = models.ManyToManyField(Course, blank=True)
 
     class Meta:
         app_label = 'feti'

--- a/django_project/feti/models/national_qualification_framework_subframework.py
+++ b/django_project/feti/models/national_qualification_framework_subframework.py
@@ -1,0 +1,27 @@
+from django.contrib.gis.db import models
+
+
+class NationalQualificationFrameworkSubFramework(models.Model):
+
+    code = models.CharField(
+        max_length=50,
+        blank=False,
+        null=False
+    )
+
+    title = models.CharField(
+        max_length=150,
+        blank=True,
+        null=True
+    )
+
+    objects = models.GeoManager()
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return '%s - %s' % (self.code, self.title)
+
+    class Meta:
+        app_label = 'feti'

--- a/django_project/feti/models/pre_2009_national_qualifications_framework.py
+++ b/django_project/feti/models/pre_2009_national_qualifications_framework.py
@@ -1,0 +1,21 @@
+from django.contrib.gis.db import models
+
+
+class Pre2009NationalQualificationsFramework(models.Model):
+
+    level = models.CharField(
+        max_length=150,
+        blank=False,
+        null=False
+    )
+
+    objects = models.GeoManager()
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return self.level
+
+    class Meta:
+        app_label = 'feti'

--- a/django_project/feti/models/qual_class.py
+++ b/django_project/feti/models/qual_class.py
@@ -1,0 +1,19 @@
+from django.contrib.gis.db import models
+
+
+class QualClass(models.Model):
+    title = models.CharField(
+        max_length=150,
+        blank=False,
+        null=False)
+
+    objects = models.GeoManager()
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return self.title
+
+    class Meta:
+        app_label = 'feti'

--- a/django_project/feti/models/qualification_type.py
+++ b/django_project/feti/models/qualification_type.py
@@ -1,0 +1,19 @@
+from django.contrib.gis.db import models
+
+
+class QualificationType(models.Model):
+    type = models.CharField(
+        max_length=150,
+        blank=False,
+        null=False)
+
+    objects = models.GeoManager()
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return self.type
+
+    class Meta:
+        app_label = 'feti'

--- a/django_project/feti/models/subfield_of_study.py
+++ b/django_project/feti/models/subfield_of_study.py
@@ -1,0 +1,21 @@
+"""Model class for Subfield of course"""
+
+from django.contrib.gis.db import models
+
+
+class SubFieldOfStudy(models.Model):
+    learning_subfield = models.CharField(
+        max_length=150,
+        blank=False,
+        null=False)
+
+    objects = models.GeoManager()
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return self.learning_subfield
+
+    class Meta:
+        app_label = 'feti'

--- a/django_project/feti/serializers/address_serializer.py
+++ b/django_project/feti/serializers/address_serializer.py
@@ -7,3 +7,4 @@ __author__ = 'irwan'
 class AddressSerializer(serializers.ModelSerializer):
     class Meta:
         model = Address
+        fields = '__all__'

--- a/django_project/feti/serializers/campus_serializer.py
+++ b/django_project/feti/serializers/campus_serializer.py
@@ -8,6 +8,7 @@ __author__ = 'irwan'
 class CampusSerializer(serializers.ModelSerializer):
     class Meta:
         model = Campus
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(CampusSerializer, self).to_representation(instance)

--- a/django_project/feti/serializers/course_serializer.py
+++ b/django_project/feti/serializers/course_serializer.py
@@ -7,6 +7,7 @@ __author__ = 'irwan'
 class CourseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Course
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(CourseSerializer, self).to_representation(instance)

--- a/django_project/feti/serializers/favorite_serializer.py
+++ b/django_project/feti/serializers/favorite_serializer.py
@@ -10,6 +10,7 @@ __date__ = '02/11/16'
 class FavoriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = CampusCoursesFavorite
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(FavoriteSerializer, self).to_representation(instance)

--- a/django_project/feti/serializers/occupation_serializer.py
+++ b/django_project/feti/serializers/occupation_serializer.py
@@ -9,6 +9,7 @@ __author__ = 'irwan'
 class OccupationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Occupation
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(OccupationSerializer, self).to_representation(instance)

--- a/django_project/feti/serializers/provider_serializer.py
+++ b/django_project/feti/serializers/provider_serializer.py
@@ -9,6 +9,7 @@ __author__ = 'irwan'
 class ProviderSerializer(serializers.ModelSerializer):
     class Meta:
         model = Provider
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(ProviderSerializer, self).to_representation(instance)

--- a/django_project/feti/serializers/step_detail_serializer.py
+++ b/django_project/feti/serializers/step_detail_serializer.py
@@ -7,6 +7,7 @@ __author__ = 'irwan'
 class StepDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = StepDetail
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(StepDetailSerializer, self).to_representation(instance)

--- a/django_project/feti/serializers/step_detail_serializer.py
+++ b/django_project/feti/serializers/step_detail_serializer.py
@@ -10,4 +10,12 @@ class StepDetailSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         res = super(StepDetailSerializer, self).to_representation(instance)
+        if instance.course.all():
+            res['course_detail'] = []
+            for course in instance.course.all():
+                data = {
+                    'saqa_id': course.national_learners_records_database,
+                    'title': course.course_description
+                }
+                res['course_detail'].append(data)
         return res

--- a/django_project/feti/static/feti/css/feti-theme.css
+++ b/django_project/feti/static/feti/css/feti-theme.css
@@ -197,3 +197,7 @@ body {
 select[multiple].form-control, select[multiple].form-control.focus, select[multiple].form-control:focus{
     height: 500px;
 }
+
+.step-course a:hover {
+    text-decoration: underline;
+}

--- a/django_project/feti/static/feti/html/ncap1.html
+++ b/django_project/feti/static/feti/html/ncap1.html
@@ -1,0 +1,201 @@
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js" type="text/javascript"></script>
+        <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+        <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
+         <script>
+             $(function () {
+                 $(document).tooltip();
+             });
+        </script>
+        <style>
+        label {
+        display: inline-block;
+        width: 5em;
+        }
+        </style>
+
+        <link rel="stylesheet" href="/includes/style/stylev3.css" type="text/css" />
+        <link rel="stylesheet" href="/includes/fonts/stylesheet.css" type="text/css" />
+
+        <!--[if IE 7]>
+        <link href="/includes/style/ie7.css" media="screen" rel="stylesheet" type="text/css" />
+        <![endif]-->
+        <!--[if gt IE 7]>
+        <link href="/includes/style/ie8.css" media="screen" rel="stylesheet" type="text/css" />
+        <![endif]-->
+
+        <script type="text/javascript" src="/includes/js/global.js"></script>
+
+        <title>Learning Providers By General Qualification</title>
+        <meta http-equiv="pragma" content="no-cache">
+        <meta http-equiv="expires" content="-1">
+
+    </head>
+
+    <body>
+        <div id="ContentWrapper">
+            <div id="HeaderContainer">
+                <div id="Header" style="height:113px;">
+                    <div id="HeaderLogo">
+                        <a href="/"><img src="/includes/images/DHETLogo.png" /></a>
+                    </div>
+
+
+                    <div style="clear:both;"></div>
+
+
+                    <!-- Login Bar Start -->
+                        <div class="loginBar">
+
+                            <ul class="loginBarContent">
+
+
+                                <li class="userlogin">
+                                        <a href="/login">Login</a>
+                                </li>
+                            </ul>
+
+                            <div class="loginBarEdge"></div>
+                            <div style="clear:both;"></div>
+
+                        </div>
+                        <div style="clear:both;"></div>
+                        <!-- Login Bar End -->
+
+
+                </div>
+
+                <div id="Menu">
+                        <div class="MenuItem First"><a title="Go to the Home page" href="/">Home</a></div>
+                        <div class="MenuSpacer"></div>
+                        <div class="MenuItem"><a title="Career Guidance Questionnaire" href="/questionnaire">Career Questionnaire</a></div>
+                        <div class="MenuSpacer"></div>
+                        <div class="MenuItem"><a title="Descriptions of Careers on this website" href="/occupations">Occupations</a></div>
+                        <div class="MenuSpacer"></div>
+                        <div class="MenuItem"><a title="Accredited Learning Providers in SA" href="/learningproviders">Where to Study</a></div>
+                        <div class="MenuSpacer"></div>
+                        <div class="MenuItem"><a title="Accredited Qualifications in SA" href="/qualifications">What to Study</a></div>
+                        <div class="MenuSpacer"></div>
+                        <div class="MenuItem"><a title="Learnerships" href="/learnerships">Learnerships</a></div>
+                        <div class="MenuSpacer"></div>
+                        <div class="MenuItem"><a title="Contact Us" href="/contacts">Contact Us</a></div>
+
+
+                        <div style="clear:both;"></div>
+                    </div>
+
+            </div>
+
+            <div class="BodyWrapper">
+
+
+<div class="ContentBlock">
+    <div class="Padding">
+        <div class="SidebarLeft">
+
+            <div class="sidebar-quote">
+
+                <p>"Education is the most powerful weapon which you can use to change the world."</p>
+                <p class="author">- Nelson Mandela</p>
+           </div>
+
+        </div>
+        <div class="BodyPanel642 clearfix">
+            <div class="BreadCrumb">
+                <div class="Crumb"><a href="/">Home</a></div>
+                <div class="Crumb">&nbsp;>&nbsp;</div>
+                <div class="Crumb"><a href="/occupations">Occupations</a></div>
+                <div class="Crumb">&nbsp;>&nbsp;</div>
+                <div class="Crumb"><a href="/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6">Aeronautical Engineer</a></div>
+                <div class="Crumb">&nbsp;>&nbsp;</div>
+                <div class="Crumb"><a href="/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da">Learning Pathway</a></div>
+                <div class="Crumb">&nbsp;>&nbsp;</div>
+                <div class="Crumb">Learning Providers that offer Bachelor of Mechanical Engineering</div>
+                <div style="clear:both;"></div>
+            </div>
+            <hr class="hrdivider" />
+
+
+                    <b><a href="/learningprovider/340892ed-eba6-46a8-9594-55609b23059a/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6/generalqualification/a83f6d72-f87c-4ff0-ad94-b7b61589de76">North West University</a></b><br /><br />
+                        <b>Qualifications</b><br />
+Bachelor of Engineering (SAQA Qualification ID : 72780, NQF Level : NQF Level 08) <br />
+                    <hr class="hrdivider" />
+                    <b><a href="/learningprovider/ef8c419a-776f-4a47-9a1d-3acb15bbab9f/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6/generalqualification/a83f6d72-f87c-4ff0-ad94-b7b61589de76">University of Cape Town</a></b><br /><br />
+                        <b>Qualifications</b><br />
+Bachelor of Science: Engineering: Mechanical Engineering (SAQA Qualification ID : 13977, NQF Level : NQF Level 08) <br />
+                    <hr class="hrdivider" />
+                    <b><a href="/learningprovider/899acbe4-8a82-4d4f-8dc7-03d1c066b3a6/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6/generalqualification/a83f6d72-f87c-4ff0-ad94-b7b61589de76">University of Johannesburg</a></b><br /><br />
+                        <b>Qualifications</b><br />
+Bachelor of Engineering: Mechanical Engineering: IT (SAQA Qualification ID : 73788, NQF Level : NQF Level 08) <br />
+Bachelor of Engineering: Mechanical Engineering (SAQA Qualification ID : 73787, NQF Level : NQF Level 08) <br />
+                    <hr class="hrdivider" />
+                    <b><a href="/learningprovider/ae2e9b6f-62f7-465f-9570-94583d1736bc/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6/generalqualification/a83f6d72-f87c-4ff0-ad94-b7b61589de76">University of KwaZulu-Natal</a></b><br /><br />
+                        <b>Qualifications</b><br />
+Bachelor of Science: Engineering (SAQA Qualification ID : 73017, NQF Level : NQF Level 08) <br />
+                    <hr class="hrdivider" />
+                    <b><a href="/learningprovider/964d8d67-381e-4a44-a5b2-2f25e6d8e1fc/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6/generalqualification/a83f6d72-f87c-4ff0-ad94-b7b61589de76">University of Pretoria</a></b><br /><br />
+                        <b>Qualifications</b><br />
+Bachelor of Engineering: Mechanical Engineering (SAQA Qualification ID : 5129, NQF Level : NQF Level 08) <br />
+                    <hr class="hrdivider" />
+                    <b><a href="/learningprovider/ead0483e-3ab5-40dc-b005-d990c1a96161/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6/generalqualification/a83f6d72-f87c-4ff0-ad94-b7b61589de76">University of Stellenbosch</a></b><br /><br />
+                        <b>Qualifications</b><br />
+Bachelor of Engineering (SAQA Qualification ID : 13990, NQF Level : NQF Level 08) <br />
+                    <hr class="hrdivider" />
+                    <b><a href="/learningprovider/de0a4130-1460-469b-b7cb-cc7e79971d65/learningpathway/d3d29a9a-af58-4668-9fcc-71ec9e1dc8da/occupation/a899dc33-397e-42aa-865a-8e4eb2eae7f6/generalqualification/a83f6d72-f87c-4ff0-ad94-b7b61589de76">University of Witwatersrand</a></b><br /><br />
+                        <b>Qualifications</b><br />
+Bachelor of Science: Engineering (SAQA Qualification ID : 14004, NQF Level : NQF Level 08) <br />
+                    <hr class="hrdivider" />
+
+        </div><!-- Close BodyPanel640 -->
+        <br class="clear" />
+    </div>
+</div>
+
+            </div>
+
+
+            <div class="Footer">
+
+                <div class="ContentBlock">
+                    <div class="feedbackBanner"><a href="/Feedback">Click here to give us feedback on how we can improve.</a></div>
+
+                    <hr class="hrdivider" />
+
+                    <div id="LandingPageFooters">
+
+
+
+
+                        <div class="initiativeLogos"><img src="/includes/images/DHETLogo.png" /></div>
+                        <div class="initiativeLogos"><img src="/includes/images/kheta-logo.png" /></div>
+                        <div class="clear"></div>
+
+                    </div>
+
+                    <hr class="hrdivider" />
+
+                    <div class="disclaimer"><a href="http://www.dhet.gov.za/SitePages/Foot_TermsOfUse.aspx"> Terms of use</a>
+                       </div>
+                </div>
+            </div>
+            <br />
+
+        </div>
+
+     <script>
+            (function (i, s, o, g, r, a, m) {
+                i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+                    (i[r].q = i[r].q || []).push(arguments)
+                }, i[r].l = 1 * new Date(); a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+            })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+            ga('create', 'UA-39743697-1', 'careerhelp.org.za');
+            ga('send', 'pageview');
+        </script>
+
+    </body>
+</html>

--- a/django_project/feti/static/feti/js/scripts/templates/step-detail.html
+++ b/django_project/feti/static/feti/js/scripts/templates/step-detail.html
@@ -1,8 +1,14 @@
 <table>
     <tr style="margin-bottom: 30px">
         <td style="width: 50px" valign="top">Step <%- step_number %></td>
-        <td valign="top" style="padding-bottom: 20px"><a href="/#map/course/<%- title %>"><h4><%- title %></h4></a>
+        <td valign="top" style="padding-bottom: 20px"><h4><%- title %></h4>
             <%- detail %>
+            <% if (typeof(course_detail) !== "undefined") { %>
+                <h5>Courses:</h5>
+                <% _.each(course_detail, function(course) { %>
+                    <div class="step-course"><a href="/#map/course/saqa_id=<%= course.saqa_id %>"><%= course.title %></a></div>
+                <% }); %>
+            <% } %>
         </td>
     </tr>
 </table>

--- a/django_project/feti/static/feti/js/scripts/templates/step-detail.html
+++ b/django_project/feti/static/feti/js/scripts/templates/step-detail.html
@@ -6,7 +6,7 @@
             <% if (typeof(course_detail) !== "undefined") { %>
                 <h5>Courses:</h5>
                 <% _.each(course_detail, function(course) { %>
-                    <div class="step-course"><a href="/#map/course/saqa_id=<%= course.saqa_id %>"><%= course.title %></a></div>
+                    <div class="step-course"><a href="#map/course/saqa_id=<%= course.saqa_id %>"><%= course.title %></a></div>
                 <% }); %>
             <% } %>
         </td>

--- a/django_project/feti/static/feti/js/scripts/views/search.js
+++ b/django_project/feti/static/feti/js/scripts/views/search.js
@@ -108,6 +108,7 @@ define([
             var new_url = ['map'];
             var mode = this.$el.find('.search-category').find('.search-option.active').data('mode');
             if(Common.CurrentSearchMode != mode) {
+                $('#result-title').find('#result-title-'+Common.CurrentSearchMode).hide();
                 Common.CurrentSearchMode = mode;
             }
 

--- a/django_project/feti/static/feti/js/scripts/views/sidebar.js
+++ b/django_project/feti/static/feti/js/scripts/views/sidebar.js
@@ -83,9 +83,7 @@ define([
             }
         },
         updateResultTitle: function(number_result, mode, query) {
-            if(mode == 'occupation') {
-                this.hideOccupationDetail();
-            }
+            this.hideOccupationDetail();
             this.clearContainerDiv(mode);
             if(number_result == 0) {
                 this.showEmptyResult(mode);

--- a/django_project/feti/utilities/utilities.py
+++ b/django_project/feti/utilities/utilities.py
@@ -2,11 +2,10 @@
 __author__ = 'Christian Christelis <christian@kartoza.com>'
 __date__ = '16/09/16'
 import requests
-from core.settings.secret import GOOGLE_DISTANCE_MATRIX
 
 
 def get_travel_time(origin, destination, response_type='text'):
-    ''' Get the travel time between two positions.
+    """Get the travel time between two positions.
 
     :param origin: The origin.
     :type origin: basestring
@@ -16,7 +15,12 @@ def get_travel_time(origin, destination, response_type='text'):
     :type response_type: basestring
 
     :return: Travel time in words text or seconds int.
-    '''
+    """
+    try:
+        from core.settings.secret import GOOGLE_DISTANCE_MATRIX
+    except ImportError:
+        return
+
     data = {
         'url': GOOGLE_DISTANCE_MATRIX['url'],
         'units': 'imperial',

--- a/django_project/feti/utils.py
+++ b/django_project/feti/utils.py
@@ -1,12 +1,16 @@
+import re
+import os
+from django.conf import settings
+import urllib
+import requests
+from bs4 import BeautifulSoup
+from urllib.error import HTTPError, URLError
+from django.core.files import File
+
 __author__ = 'Irwan Fathurrahman <irwan@kartoza.com>'
 __date__ = '16/09/16'
 __license__ = "GPL"
 __copyright__ = 'kartoza.com'
-
-import re
-import urllib
-from bs4 import BeautifulSoup
-from urllib.error import HTTPError, URLError
 
 
 def cleaning(text):
@@ -17,6 +21,21 @@ def cleaning(text):
 def beautify(html_doc):
     soup = BeautifulSoup(html_doc, 'html.parser')
     return soup
+
+
+def get_raw_soup(url):
+    trying = 0
+    html_doc = ''
+    while True:
+        try:
+            html_doc = requests.get(url)
+            break
+        except (HTTPError, URLError):
+            trying += 1
+            print("connection error, trying again - %d" % trying)
+            if trying >= 5:
+                break
+    return html_doc
 
 
 def get_soup(url):
@@ -32,3 +51,25 @@ def get_soup(url):
             if trying >= 5:
                 break
     return beautify(html_doc)
+
+
+def open_saved_html(folder, filename):
+    full_filename = os.path.join(settings.MEDIA_ROOT, folder, filename + '.html')
+    try:
+        with open(full_filename) as f:
+            return BeautifulSoup(f, 'html.parser')
+    except FileNotFoundError:
+        return
+
+
+def save_html(folder, filename, content):
+
+    # create the folder if it doesn't exist.
+    try:
+        os.mkdir(os.path.join(settings.MEDIA_ROOT, folder))
+    except OSError:
+        pass
+
+    full_filename = os.path.join(settings.MEDIA_ROOT, folder, filename + '.html')
+    with open(full_filename, 'wb') as file:
+        file.write(content)

--- a/django_project/feti/utils.py
+++ b/django_project/feti/utils.py
@@ -54,9 +54,9 @@ def get_soup(url):
 
 
 def open_saved_html(folder, filename):
-    full_filename = os.path.join(settings.MEDIA_ROOT, folder, filename + '.html')
+    full_filename = os.path.join(settings.MEDIA_ROOT, folder, cleaning(filename) + '.html')
     try:
-        with open(full_filename) as f:
+        with open(full_filename, 'r', encoding='ISO-8859-1') as f:
             return BeautifulSoup(f, 'html.parser')
     except FileNotFoundError:
         return

--- a/django_project/feti/views/api.py
+++ b/django_project/feti/views/api.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.gis.geos import Polygon, Point
 from django.contrib.gis.measure import Distance
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.core.exceptions import MultipleObjectsReturned
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from haystack.query import RelatedSearchQuerySet, SQ, SearchQuerySet
@@ -16,6 +17,7 @@ from haystack.inputs import Clean
 from feti.models.campus import Campus
 from feti.models.occupation import Occupation
 from feti.models.campus_course_entry import CampusCourseEntry
+from feti.models.course import Course
 from feti.serializers.campus_serializer import CampusSerializer
 from feti.serializers.occupation_serializer import OccupationSerializer
 from feti.serializers.favorite_serializer import FavoriteSerializer
@@ -125,13 +127,38 @@ class ApiCourse(SearchCampus):
         return SearchCampus.get(self, request)
 
     def filter_model(self, query):
-        sqs = SearchQuerySet().filter(
-            course_course_description=query,
-            campus_location_isnull='false',
-        ).models(CampusCourseEntry)
-        campuses = Campus.objects.filter(id__in=set([x.object.campus.id for x in sqs]))
-        # Only shows this courses
-        self.additional_context['courses'] = set([x.object.course_id for x in sqs])
+        sqs = None
+        campuses = None
+
+        if '=' in query:
+            queries = query.split('=')
+            if 'saqa_id' in queries[0] and len(queries) > 1:
+                saqa_id = queries[1].strip()
+                try:
+                    sqs = SearchQuerySet().filter(
+                        national_learners_records_database=saqa_id
+                    ).models(Course)
+                    courses_id = [l.object.id for l in sqs]
+                    campus_ids = SearchQuerySet().filter(
+                        courses_id__contains=courses_id[0]
+                    ).models(Campus)
+
+                    campuses = Campus.objects.filter(id__in=set([x.object.id for x in campus_ids]))
+
+                    self.additional_context['courses'] = courses_id
+                except MultipleObjectsReturned as e:
+                    print(e)
+
+        if not sqs:
+            sqs = SearchQuerySet().filter(
+                course_course_description=query,
+                campus_location_isnull='false',
+            ).models(CampusCourseEntry)
+
+            campuses = Campus.objects.filter(id__in=set([x.object.campus.id for x in sqs]))
+            # Only shows this courses
+            self.additional_context['courses'] = set([x.object.course_id for x in sqs])
+
         return campuses
 
     def additional_filter(self, model, query):

--- a/django_project/feti/views/api.py
+++ b/django_project/feti/views/api.py
@@ -139,11 +139,10 @@ class ApiCourse(SearchCampus):
                         national_learners_records_database=saqa_id
                     ).models(Course)
                     courses_id = [l.object.id for l in sqs]
-                    campus_ids = SearchQuerySet().filter(
-                        courses_id__contains=courses_id[0]
-                    ).models(Campus)
 
-                    campuses = Campus.objects.filter(id__in=set([x.object.id for x in campus_ids]))
+                    campuses = Campus.objects.filter(
+                        courses__in=courses_id
+                    )
 
                     self.additional_context['courses'] = courses_id
                 except MultipleObjectsReturned as e:

--- a/django_project/map_administrative/migrations/0003_administrative_data_migrations.py
+++ b/django_project/map_administrative/migrations/0003_administrative_data_migrations.py
@@ -85,7 +85,3 @@ class Migration(migrations.Migration):
     dependencies = [
         ('map_administrative', '0002_province'),
     ]
-
-    operations = [
-        migrations.RunPython(import_countries),
-    ]

--- a/django_project/map_administrative/serializers/country_serializer.py
+++ b/django_project/map_administrative/serializers/country_serializer.py
@@ -13,6 +13,7 @@ class CountrySerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Country
         geo_field = 'polygon_geometry'
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(CountrySerializer, self).to_representation(instance)

--- a/django_project/map_administrative/serializers/province_serializer.py
+++ b/django_project/map_administrative/serializers/province_serializer.py
@@ -13,6 +13,7 @@ class ProvinceSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Province
         geo_field = 'polygon_geometry'
+        fields = '__all__'
 
     def to_representation(self, instance):
         res = super(ProvinceSerializer, self).to_representation(instance)


### PR DESCRIPTION
This PR fixes : 
- [x] Update the course model to accomodate all the fields from saqa qualification page ( example: http://regqs.saqa.org.za/viewQualification.php?id=78694 ) e.g. we need to add PURPOSE AND RATIONALE OF THE QUALIFICATION field and etc. (https://github.com/kartoza/feti/issues/307)
- [x] Create a management command to remove duplicated courses
- [x] Change courses in stepdetail into many to many relationship ( https://github.com/kartoza/feti/issues/306 )
- [x] Update occupation scraper to get all the courses from learning pathway in ncap ( https://github.com/kartoza/feti/issues/306 )
- [x] Update course scraper, and have been tested
- [x] Shows clickable list of courses in learning pathway
- [x] Update course search method to get campuses from saqa qualification id

Tasks remaining : 
- [x] Fix test case
