### PR TITLE
Add tag for elasticsearch image

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -36,7 +36,7 @@ elasticsearch:
   container_name: feti-elasticsearch
   restart: on-failure:5
   #  read_only: true
-  image: elasticsearch
+  image: elasticsearch:2.4.2
   hostname: elasticsearch
   environment:
     - HAYSTACK_PORT=9200

--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -15,7 +15,7 @@ markdown
 django-filter
 # Django haystack support
 django-haystack
-elasticsearch
+elasticsearch==5.0.1
 django-leaflet==0.16.0
 django-geojson==2.8.0
 django-nested-inline


### PR DESCRIPTION
If we used the latest elasticsearch docker image, the search won't work.