### PR TITLE
all or nothing share options

### DIFF
--- a/django_project/feti/static/js/scripts/views/map.js
+++ b/django_project/feti/static/js/scripts/views/map.js
@@ -365,13 +365,22 @@ define([
             $('#share-email-button').hide();
             $('#share-twitter-button').hide();
             $('#share-url-button').hide();
+            $('#share-embed-code').hide();
         },
         showShareBar: function () {
             var mode = Common.CurrentSearchMode;
-            $('#share-twitter-button').show();
-            $('#share-url-button').show();
+
+            // No need to share link and twitter in favorites
+            if (mode != 'favorites') {
+                $('#share-twitter-button').show();
+                $('#share-url-button').show();
+            } else {
+                $('#share-twitter-button').hide();
+                $('#share-url-button').hide();
+            }
             $('#share-pdf-button').show();
             $('#share-email-button').show();
+            $('#share-embed-code').show();
         },
         _disableOtherControlButtons: function (currentControl) {
             for (var i = 0; i < this.locationFilterBar._buttons.length; i++) {

--- a/django_project/feti/static/js/scripts/views/map.js
+++ b/django_project/feti/static/js/scripts/views/map.js
@@ -368,15 +368,8 @@ define([
         },
         showShareBar: function () {
             var mode = Common.CurrentSearchMode;
-
-            // No need to share link and twitter in favorites
-            if (mode != 'favorites') {
-                $('#share-twitter-button').show();
-                $('#share-url-button').show();
-            } else {
-                $('#share-twitter-button').hide();
-                $('#share-url-button').hide();
-            }
+            $('#share-twitter-button').show();
+            $('#share-url-button').show();
             $('#share-pdf-button').show();
             $('#share-email-button').show();
         },

--- a/django_project/feti/static/js/scripts/views/search.js
+++ b/django_project/feti/static/js/scripts/views/search.js
@@ -439,7 +439,7 @@ define([
                 highlight = 'Search for courses';
             } else if (mode == "occupation") {
                 $button = this.$occupation_button;
-                highlight = 'Search for occuption';
+                highlight = 'Search for occupation';
             } else if (mode == "favorites") {
                 $button = this.$favorites_button;
                 highlight = '';


### PR DESCRIPTION
Fix #451 
all or nothing share options.

show no share button on empty search field
![screenshot from 2017-04-03 12-57-10](https://cloud.githubusercontent.com/assets/26101337/24597028/5eb1c3a4-186d-11e7-97f6-357c080074e7.png)
![screenshot from 2017-04-03 12-57-20](https://cloud.githubusercontent.com/assets/26101337/24597036/66d15e0a-186d-11e7-96f7-85ec1983bd9e.png)

edited the occupation empty search field from "search for occuption" to "search for occupation"
![screenshot from 2017-04-03 12-58-03](https://cloud.githubusercontent.com/assets/26101337/24597066/92c795ec-186d-11e7-9839-2f7ec8360c7f.png)