### PR TITLE
Fix search not working in ie

### DIFF
--- a/django_project/feti/static/js/scripts/collections/category.js
+++ b/django_project/feti/static/js/scripts/collections/category.js
@@ -78,7 +78,10 @@ define([
             });
         },
         getRegex: function (character) {
-            return new RegExp(character, 'gi');
+            if (typeof character === 'string' || character instanceof String){
+                return new RegExp(character, 'gi');
+            }
+            return new RegExp(character);
         }
     });
 });


### PR DESCRIPTION
This fixes #302 

But it seems the layout a bit off in IE

![image](https://cloud.githubusercontent.com/assets/2271663/25084176/574424a4-2385-11e7-9222-84e02b657f95.png)


Note:
IE Version 11.0.14393