### PR TITLE
avoid occupation detail rendered twice

### DIFF
--- a/django_project/feti/static/js/scripts/views/occupation-view.js
+++ b/django_project/feti/static/js/scripts/views/occupation-view.js
@@ -60,18 +60,18 @@ define([
             var that = this;
             $('.selected-indicator-right .fa').hide();
             that.$el.find('.fa').show();
-            that.$detail.html('<div class="occupation-detail-loading"><img height="100%" src="/static/feti/images/spinner.gif"></div>');
             if(!that.$detail.is(":visible")) {
+                that.$detail.html('<div class="occupation-detail-loading"><img height="100%" src="/static/feti/images/spinner.gif"></div>');
                 that.$detail.show("slide", {direction: "right"}, 500);
+                $.ajax({
+                    url: '/api/occupation?id=' + that.model.attributes.id,
+                    success: function (response) {
+                        that.occupationDetail = response;
+                        that.$detail.html(that.detailTemplate(that.occupationDetail));
+                        that.renderPathways();
+                    }
+                });
             }
-            $.ajax({
-                url: '/api/occupation?id=' + that.model.attributes.id,
-                success: function (response) {
-                    that.occupationDetail = response;
-                    that.$detail.html(that.detailTemplate(that.occupationDetail));
-                    that.renderPathways();
-                }
-            });
         },
         render: function () {
             this.$el.empty();


### PR DESCRIPTION
fix #573 
Occupation Backbone view model is destroyed in one page refresh cycle. I haven't found that but there is another way to avoid that: by avoiding occupation detail rendered twice. I also found a way to boost the performance of this workflow by replacing ajax request with structured backbone view. I will make a separate PR for that.

#587  <- for replacing ajax request
#588 <- for destroyed occupation model