### PR TITLE
Boundary filter

### DIFF
--- a/django_project/feti/api_views/common_search.py
+++ b/django_project/feti/api_views/common_search.py
@@ -274,6 +274,9 @@ class CommonSearch(object):
                         options['radius']
                     )
 
+            if not sqs:
+                continue
+
             sqs = self.advanced_filter(sqs, options)
 
             for result in sqs:

--- a/django_project/map_administrative/views.py
+++ b/django_project/map_administrative/views.py
@@ -15,16 +15,14 @@ def get_boundary(administrative):
     boundary = None
     if (administrative):
         administratives = administrative.split(",")
-        index = 0
         try:
-            for administrative in administratives:
+            for index, administrative in enumerate(administratives):
                 if index == 0:
                     boundary = Province.objects.get(name=administrative)
                 elif index == 1:
                     boundary = District.objects.get(name=administrative, province=boundary)
                 elif index == 2:
                     boundary = Municipality.objects.get(name=administrative, district=boundary)
-                index += 1
         except Country.DoesNotExist:
             pass
         except Province.DoesNotExist:


### PR DESCRIPTION
fix #597 
When multiple `saqa_id`s query performed on a polygon filter, there is a possibility that a specific course is not found in the polygon. We need to skip related course from advance filter.