### PR TITLE
Null model

### DIFF
--- a/django_project/feti/static/js/scripts/views/occupation-view.js
+++ b/django_project/feti/static/js/scripts/views/occupation-view.js
@@ -86,7 +86,7 @@ define([
         },
         destroy: function () {
             this.model.destroy();
-            this.model = null;
+            this.model = this.model ? this.model : null;
             this.$el.remove();
             return Backbone.View.prototype.remove.call(this);
         },


### PR DESCRIPTION
fix #588 
avoid view's model attribute become null. I'm still not sure why we need to set model to null on destroy function though.