### PR TITLE
remove the event mouseover to open a popup. open only on click event

### DIFF
--- a/django_project/feti/static/js/scripts/models/occupation.js
+++ b/django_project/feti/static/js/scripts/models/occupation.js
@@ -69,14 +69,7 @@ define([
                     marker.on('click', function (e) {
                         e.originalEvent.preventDefault();
                         that.set('marker_clicked', true);
-                    });
-                    marker.on('mouseover', function (e) {
                         this.openPopup();
-                    });
-                    marker.on('mouseout', function (e) {
-                        if (!that.get('marker_clicked')) {
-                            this.closePopup();
-                        }
                     });
                     marker.on('popupclose', function (e) {
                         that.set('marker_clicked', false);

--- a/django_project/feti/static/js/scripts/models/provider.js
+++ b/django_project/feti/static/js/scripts/models/provider.js
@@ -95,14 +95,7 @@ define([
                 marker.on('click', function (e) {
                     e.originalEvent.preventDefault();
                     that.set('marker_clicked', true);
-                });
-                marker.on('mouseover', function (e) {
                     this.openPopup();
-                });
-                marker.on('mouseout', function (e) {
-                    if (!that.get('marker_clicked')) {
-                        this.closePopup();
-                    }
                 });
                 marker.on('popupclose', function (e) {
                     that.set('marker_clicked', false);


### PR DESCRIPTION
![feti-fixed-issue-497-4](https://user-images.githubusercontent.com/35932320/43257278-aaf10f96-90cf-11e8-97f0-e9ac314fe384.gif)

As you can see, on the "What to study" tab, I had to reload the page because campus markers were on the map but this is another story.