### PR TITLE
show all shares button

### DIFF
--- a/django_project/feti/static/js/scripts/views/map.js
+++ b/django_project/feti/static/js/scripts/views/map.js
@@ -426,18 +426,9 @@ define([
             $('#share-embed-code').hide();
         },
         showShareBar: function () {
-            var mode = Common.CurrentSearchMode;
-
-            // No need to share link and twitter in favorites
-            if (mode != 'favorites') {
-                $('#share-twitter-button').show();
-                $('#share-facebook-button').show();
-                $('#share-url-button').show();
-            } else {
-                $('#share-twitter-button').hide();
-                $('#share-facebook-button').hide();
-                $('#share-url-button').hide();
-            }
+            $('#share-twitter-button').show();
+            $('#share-facebook-button').show();
+            $('#share-url-button').show();
             $('#share-pdf-button').show();
             $('#share-email-button').show();
             $('#share-embed-code').show();


### PR DESCRIPTION
fix #609 

- Share buttons on favourites:
![screenshot from 2018-07-30 10-21-57](https://user-images.githubusercontent.com/26101337/43376044-d3a9cb88-93e2-11e8-9496-ab9e50b44518.png)

- Share buttons on course:
![screenshot from 2018-07-30 10-21-32](https://user-images.githubusercontent.com/26101337/43376059-e290d628-93e2-11e8-8d5b-779019f4d822.png)

- Share buttons on provider:
![screenshot from 2018-07-30 10-21-20](https://user-images.githubusercontent.com/26101337/43376069-f335a2c4-93e2-11e8-9cfd-3b1249638075.png)

- No share button on occupation:
![screenshot from 2018-07-30 10-21-39](https://user-images.githubusercontent.com/26101337/43376075-fc25326e-93e2-11e8-910d-d309e8297fec.png)

- PDF is working, here is when I printed pdf from favourites:
![screenshot from 2018-07-30 10-15-42](https://user-images.githubusercontent.com/26101337/43376090-0cb234ec-93e3-11e8-840e-3459d5edb9c9.png)